### PR TITLE
Change the kubeconfig hostPath, if k3s agent node just runs in splited mode.

### DIFF
--- a/manifests/kilo-k3s-flannel.yaml
+++ b/manifests/kilo-k3s-flannel.yaml
@@ -96,4 +96,4 @@ spec:
           path: /var/lib/kilo
       - name: kubeconfig
         hostPath: 
-          path: /etc/rancher/k3s/k3s.yaml
+          path: /var/lib/rancher/k3s/agent/kubeconfig.yaml

--- a/manifests/kilo-k3s.yaml
+++ b/manifests/kilo-k3s.yaml
@@ -158,4 +158,4 @@ spec:
           path: /var/lib/kilo
       - name: kubeconfig
         hostPath: 
-          path: /etc/rancher/k3s/k3s.yaml
+          path: /var/lib/rancher/k3s/agent/kubeconfig.yaml


### PR DESCRIPTION
feat: Change the kubeconfig hostPath, if k3s agent node just runs in splited mode.