### PR TITLE
pkg/mesh,pkg/wireguard: allow DNS name endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ Kilo allows the topology of the encrypted network to be completely customized.
 
 ### Step 4: ensure nodes have public IP
 
-At least one node in each location must have a public IP address.
-If the public IP address is not automatically configured on the node's Ethernet device, it can be manually specified using the [kilo.squat.ai/force-external-ip](./docs/annotations.md#force-external-ip) annotation.
+At least one node in each location must have an IP address that is routable from the other locations.
+If the locations are in different clouds or private networks, then this must be a public IP address.
+If this IP address is not automatically configured on the node's Ethernet device, it can be manually specified using the [kilo.squat.ai/force-endpoint](./docs/annotations.md#force-endpoint) annotation.
 
 ### Step 5: install Kilo!
 

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -2,19 +2,22 @@
 
 The following annotations can be added to any Kubernetes Node object to configure the Kilo network.
 
-|Name|type|example|
+|Name|type|examples|
 |----|----|-------|
-|[kilo.squat.ai/force-external-ip](#force-external-ip)|CIDR|`"55.55.55.55/32"`|
-|[kilo.squat.ai/force-internal-ip](#force-internal-ip)|CIDR|`"55.55.55.55/32"`|
-|[kilo.squat.ai/leader](#leader)|string|`""`|
-|[kilo.squat.ai/location](#location)|string|`"gcp-east"`|
+|[kilo.squat.ai/force-endpoint](#force-endpoint)|host:port|`55.55.55.55:51820`, `example.com:1337|
+|[kilo.squat.ai/force-internal-ip](#force-internal-ip)|CIDR|`55.55.55.55/32`|
+|[kilo.squat.ai/leader](#leader)|string|`""`, `true`|
+|[kilo.squat.ai/location](#location)|string|`gcp-east`, `lab`|
 
-### force-external-ip
-Kilo requires at least one node in each location to have a publicly accessible IP address in order to create links to other locations.
-The Kilo agent running on each node will use heuristics to automatically detect an external IP address for the node; however, in some circumstances it may be necessary to explicitly configure the IP address, for example:
+### force-endpoint
+In order to create links between locations, Kilo requires at least one node in each location to have an endpoint, ie a `host:port` combination, that is routable from the other locations.
+If the locations are in different cloud providers or in different private networks, then the `host` portion of the endpoint should be a publicly accessible IP address, or a DNS name that resolves to a public IP, so that the other locations can route packets to it.
+The Kilo agent running on each node will use heuristics to automatically detect an external IP address for the node and correctly configure its endpoint; however, in some circumstances it may be necessary to explicitly configure the endpoint to use, for example:
  * _no automatic public IP on ethernet device_: on some cloud providers it is common for nodes to be allocated a public IP address but for the Ethernet devices to only be automatically configured with the private network address; in this case the allocated public IP address should be specified;
  * _multiple public IP addresses_: if a node has multiple public IPs but one is preferred, then the preferred IP address should be specified;
- * _IPv6_: if a node has both public IPv4 and IPv6 addresses and the Kilo network should operate over IPv6, then the IPv6 address should be specified.
+ * _IPv6_: if a node has both public IPv4 and IPv6 addresses and the Kilo network should operate over IPv6, then the IPv6 address should be specified;
+ * _dynamic IP address_: if a node has a dynamically allocated public IP address, for example an IP leased from a network provider, then a dynamic DNS name can be given can be given and Kilo will periodically lookup the IP to keep the endpoint up-to-date;
+ * _override port_: if a node should listen on a specific port that is different from the mesh's default WireGuard port, then this annotation can be used to override the port; this can be useful, for example, to ensure that two nodes operating behind the same port-forwarded NAT gateway can each be allocated a different port.
 
 ### force-internal-ip
 Kilo routes packets destined for nodes inside the same logical location using the node's internal IP address.

--- a/pkg/calico/calico
+++ b/pkg/calico/calico
@@ -1,0 +1,179 @@
+// Copyright 2019 the Kilo authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package calico
+
+import (
+	"errors"
+	"net"
+	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+	v1informers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	v1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/squat/kilo/pkg/ipset"
+	"github.com/squat/kilo/pkg/mesh"
+)
+
+type Compatibility interface {
+	Apply(*mesh.Topology, mesh.Encapsulate) error
+	Backend(mesh.Backend) mesh.Backend
+	CleanUp() error
+	Run(stop <-chan struct{}) (<-chan error, error)
+}
+
+// calico is a Calico compatibility layer.
+type calico struct {
+	client kubernetes.Interface
+	errors chan error
+	ipset  *ipset.Set
+}
+
+// New generates a new ipset.
+func New(c kubernetes.Interface) Compatibility {
+	return &calico{
+		client: c,
+		errors: make(chan error),
+		// This is a patch until Calico supports
+		// other hosts adding IPIP iptables rules.
+		ipset: ipset.New("cali40all-hosts-net"),
+	}
+}
+
+// Run implements the mesh.Compatibility interface.
+// It runs the ipset controller and forwards errors along.
+func (c *calico) Run(stop <-chan struct{}) (<-chan error, error) {
+	return c.ipset.Run(stop)
+}
+
+// CleanUp stops the compatibility layer's controllers.
+func (c *calico) CleanUp() error {
+	return c.ipset.CleanUp()
+}
+
+type backend struct {
+	backend  mesh.Backend
+	client   kubernetes.Interface
+	events   chan *mesh.NodeEvent
+	informer cache.SharedIndexInformer
+	lister   v1listers.NodeLister
+}
+
+func (c *calico) Apply(t *mesh.Topology, encapsulate mesh.Encapsulate, location string) error {
+	if encapsulate == mesh.NeverEncapsulate {
+		return nil
+	}
+	var peers []net.IP
+	for _, s := range t.segments {
+		if s.location == location {
+			peers = s.privateIPs
+			break
+		}
+	}
+	return c.ipset.Set(peers)
+}
+
+func (c *calico) Backend(b mesh.Backend) mesh.Backend {
+	ni := v1informers.NewNodeInformer(c.client, 5*time.Minute, nil)
+	return &backend{
+		backend:  b,
+		events:   make(chan *mesh.NodeEvent),
+		informer: ni,
+		lister:   v1listers.NewNodeLister(ni.GetIndexer()),
+	}
+}
+
+// Nodes implements the mesh.Backend interface.
+func (b *backend) Nodes() mesh.NodeBackend {
+	return b
+}
+
+// Peers implements the mesh.Backend interface.
+func (b *backend) Peers() mesh.PeerBackend {
+	// The Calico compatibility backend only wraps the node backend.
+	return b.backend.Peers()
+}
+
+// CleanUp removes configuration applied to the backend.
+func (b *backend) CleanUp(name string) error {
+	return b.backend.Nodes().CleanUp(name)
+}
+
+// Get gets a single Node by name.
+func (b *backend) Get(name string) (*mesh.Node, error) {
+	n, err := b.lister.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	m, err := b.backend.Nodes().Get(name)
+	if err != nil {
+		return nil, err
+	}
+	return translateNode(n, m), nil
+}
+
+// Init initializes the backend; for this backend that means
+// syncing the informer cache and the wrapped backend.
+func (b *backend) Init(stop <-chan struct{}) error {
+	if err := b.backend.Nodes().Init(stop); err != nil {
+		return err
+	}
+	go b.informer.Run(stop)
+	if ok := cache.WaitForCacheSync(stop, func() bool {
+		return b.informer.HasSynced()
+	}); !ok {
+		return errors.New("failed to sync node cache")
+	}
+	go func() {
+		w := b.backend.Nodes().Watch()
+		var ne *mesh.NodeEvent
+		for {
+			select {
+			case ne = <-w:
+				b.events <- &mesh.NodeEvent{Type: ne.Type, Node: translateNode(n, ne.Node)}
+			case <-stop:
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+// List gets all the Nodes in the cluster.
+func (b *backend) List() ([]*mesh.Node, error) {
+	ns, err := b.lister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	nodes := make([]*mesh.Node, len(ns))
+	for i := range ns {
+		nodes[i] = translateNode(ns[i])
+	}
+	return nodes, nil
+}
+
+// Set sets the fields of a node.
+func (b *backend) Set(name string, node *mesh.Node) error {
+	// The Calico compatibility backend is read-only.
+	// Proxy all writes to the underlying backend.
+	return b.backend.Nodes().Set(name, node)
+}
+
+// Watch returns a chan of node events.
+func (b *backend) Watch() <-chan *mesh.NodeEvent {
+	return b.events
+}

--- a/pkg/encapsulation/none.go
+++ b/pkg/encapsulation/none.go
@@ -1,0 +1,63 @@
+// Copyright 2019 the Kilo authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package encapsulation
+
+import (
+	"net"
+
+	"github.com/squat/kilo/pkg/iptables"
+)
+
+type none Strategy
+
+// NewNone returns an new encapsulator that does not encapsulate.
+func NewNone(strategy Strategy) Encapsulator {
+	return none(strategy)
+}
+
+// CleanUp is a no-op.
+func (n none) CleanUp() error {
+	return nil
+}
+
+// Gw always returns nil.
+func (n none) Gw(_, _ net.IP, _ *net.IPNet) net.IP {
+	return nil
+}
+
+// Index always returns 0.
+func (n none) Index() int {
+	return 0
+}
+
+// Init is a no-op.
+func (n none) Init(base int) error {
+	return nil
+}
+
+// Rules always returns an empty list.
+func (n none) Rules(_ []*net.IPNet) []iptables.Rule {
+	return nil
+}
+
+// Set is a no-op.
+func (n none) Set(_ *net.IPNet) error {
+	return nil
+}
+
+// Strategy returns the configured strategy for encapsulation.
+func (n none) Strategy() Strategy {
+	return Strategy(n)
+}

--- a/pkg/mesh/ip.go
+++ b/pkg/mesh/ip.go
@@ -72,7 +72,7 @@ func getIP(hostname string, ignoreIfaces ...int) (*net.IPNet, *net.IPNet, error)
 				continue
 			}
 			ip.Mask = mask
-			if isPublic(ip) {
+			if isPublic(ip.IP) {
 				hostPub = append(hostPub, ip)
 				continue
 			}
@@ -97,7 +97,7 @@ func getIP(hostname string, ignoreIfaces ...int) (*net.IPNet, *net.IPNet, error)
 			if isLocal(ip.IP) {
 				continue
 			}
-			if isPublic(ip) {
+			if isPublic(ip.IP) {
 				defaultPub = append(defaultPub, ip)
 				continue
 			}
@@ -118,7 +118,7 @@ func getIP(hostname string, ignoreIfaces ...int) (*net.IPNet, *net.IPNet, error)
 			if isLocal(ip.IP) {
 				continue
 			}
-			if isPublic(ip) {
+			if isPublic(ip.IP) {
 				interfacePub = append(interfacePub, ip)
 				continue
 			}
@@ -206,9 +206,9 @@ func isLocal(ip net.IP) bool {
 	return ip.IsLoopback() || ip.IsLinkLocalMulticast() || ip.IsLinkLocalUnicast()
 }
 
-func isPublic(ip *net.IPNet) bool {
+func isPublic(ip net.IP) bool {
 	// Check RFC 1918 addresses.
-	if ip4 := ip.IP.To4(); ip4 != nil {
+	if ip4 := ip.To4(); ip4 != nil {
 		switch true {
 		// Check for 10.0.0.0/8.
 		case ip4[0] == 10:
@@ -224,10 +224,10 @@ func isPublic(ip *net.IPNet) bool {
 		}
 	}
 	// Check RFC 4193 addresses.
-	if len(ip.IP) == net.IPv6len {
+	if len(ip) == net.IPv6len {
 		switch true {
 		// Check for fd00::/8.
-		case ip.IP[0] == 0xfd && ip.IP[1] == 0x00:
+		case ip[0] == 0xfd && ip[1] == 0x00:
 			return false
 		default:
 			return true

--- a/pkg/mesh/mesh_test.go
+++ b/pkg/mesh/mesh_test.go
@@ -18,6 +18,8 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/squat/kilo/pkg/wireguard"
 )
 
 func TestReady(t *testing.T) {
@@ -39,8 +41,28 @@ func TestReady(t *testing.T) {
 			ready: false,
 		},
 		{
-			name: "empty external IP",
+			name: "empty endpoint",
 			node: &Node{
+				InternalIP: internalIP,
+				Key:        []byte{},
+				Subnet:     &net.IPNet{IP: net.ParseIP("10.2.0.0"), Mask: net.CIDRMask(16, 32)},
+			},
+			ready: false,
+		},
+		{
+			name: "empty endpoint IP",
+			node: &Node{
+				Endpoint:   &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{}, Port: DefaultKiloPort},
+				InternalIP: internalIP,
+				Key:        []byte{},
+				Subnet:     &net.IPNet{IP: net.ParseIP("10.2.0.0"), Mask: net.CIDRMask(16, 32)},
+			},
+			ready: false,
+		},
+		{
+			name: "empty endpoint port",
+			node: &Node{
+				Endpoint:   &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{IP: externalIP.IP}},
 				InternalIP: internalIP,
 				Key:        []byte{},
 				Subnet:     &net.IPNet{IP: net.ParseIP("10.2.0.0"), Mask: net.CIDRMask(16, 32)},
@@ -50,16 +72,16 @@ func TestReady(t *testing.T) {
 		{
 			name: "empty internal IP",
 			node: &Node{
-				ExternalIP: externalIP,
-				Key:        []byte{},
-				Subnet:     &net.IPNet{IP: net.ParseIP("10.2.0.0"), Mask: net.CIDRMask(16, 32)},
+				Endpoint: &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{IP: externalIP.IP}, Port: DefaultKiloPort},
+				Key:      []byte{},
+				Subnet:   &net.IPNet{IP: net.ParseIP("10.2.0.0"), Mask: net.CIDRMask(16, 32)},
 			},
 			ready: false,
 		},
 		{
 			name: "empty key",
 			node: &Node{
-				ExternalIP: externalIP,
+				Endpoint:   &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{IP: externalIP.IP}, Port: DefaultKiloPort},
 				InternalIP: internalIP,
 				Subnet:     &net.IPNet{IP: net.ParseIP("10.2.0.0"), Mask: net.CIDRMask(16, 32)},
 			},
@@ -68,7 +90,7 @@ func TestReady(t *testing.T) {
 		{
 			name: "empty subnet",
 			node: &Node{
-				ExternalIP: externalIP,
+				Endpoint:   &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{IP: externalIP.IP}, Port: DefaultKiloPort},
 				InternalIP: internalIP,
 				Key:        []byte{},
 			},
@@ -77,7 +99,7 @@ func TestReady(t *testing.T) {
 		{
 			name: "valid",
 			node: &Node{
-				ExternalIP: externalIP,
+				Endpoint:   &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{IP: externalIP.IP}, Port: DefaultKiloPort},
 				InternalIP: internalIP,
 				Key:        []byte{},
 				LastSeen:   time.Now().Unix(),

--- a/pkg/mesh/topology_test.go
+++ b/pkg/mesh/topology_test.go
@@ -40,7 +40,7 @@ func setup(t *testing.T) (map[string]*Node, map[string]*Peer, []byte, uint32) {
 	nodes := map[string]*Node{
 		"a": {
 			Name:                "a",
-			ExternalIP:          e1,
+			Endpoint:            &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{IP: e1.IP}, Port: DefaultKiloPort},
 			InternalIP:          i1,
 			Location:            "1",
 			Subnet:              &net.IPNet{IP: net.ParseIP("10.2.1.0"), Mask: net.CIDRMask(24, 32)},
@@ -49,7 +49,7 @@ func setup(t *testing.T) (map[string]*Node, map[string]*Peer, []byte, uint32) {
 		},
 		"b": {
 			Name:       "b",
-			ExternalIP: e2,
+			Endpoint:   &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{IP: e2.IP}, Port: DefaultKiloPort},
 			InternalIP: i1,
 			Location:   "2",
 			Subnet:     &net.IPNet{IP: net.ParseIP("10.2.2.0"), Mask: net.CIDRMask(24, 32)},
@@ -57,7 +57,7 @@ func setup(t *testing.T) (map[string]*Node, map[string]*Peer, []byte, uint32) {
 		},
 		"c": {
 			Name:       "c",
-			ExternalIP: e3,
+			Endpoint:   &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{IP: e3.IP}, Port: DefaultKiloPort},
 			InternalIP: i2,
 			// Same location a node b.
 			Location: "2",
@@ -83,8 +83,8 @@ func setup(t *testing.T) (map[string]*Node, map[string]*Peer, []byte, uint32) {
 					{IP: net.ParseIP("10.5.0.3"), Mask: net.CIDRMask(24, 32)},
 				},
 				Endpoint: &wireguard.Endpoint{
-					IP:   net.ParseIP("192.168.0.1"),
-					Port: DefaultKiloPort,
+					DNSOrIP: wireguard.DNSOrIP{IP: net.ParseIP("192.168.0.1")},
+					Port:    DefaultKiloPort,
 				},
 				PublicKey: []byte("key5"),
 			},
@@ -119,7 +119,7 @@ func TestNewTopology(t *testing.T) {
 				segments: []*segment{
 					{
 						allowedIPs:          []*net.IPNet{nodes["a"].Subnet, nodes["a"].InternalIP, {IP: w1, Mask: net.CIDRMask(32, 32)}},
-						endpoint:            nodes["a"].ExternalIP.IP,
+						endpoint:            nodes["a"].Endpoint,
 						key:                 nodes["a"].Key,
 						location:            nodes["a"].Location,
 						cidrs:               []*net.IPNet{nodes["a"].Subnet},
@@ -130,7 +130,7 @@ func TestNewTopology(t *testing.T) {
 					},
 					{
 						allowedIPs:  []*net.IPNet{nodes["b"].Subnet, nodes["b"].InternalIP, nodes["c"].Subnet, nodes["c"].InternalIP, {IP: w2, Mask: net.CIDRMask(32, 32)}},
-						endpoint:    nodes["b"].ExternalIP.IP,
+						endpoint:    nodes["b"].Endpoint,
 						key:         nodes["b"].Key,
 						location:    nodes["b"].Location,
 						cidrs:       []*net.IPNet{nodes["b"].Subnet, nodes["c"].Subnet},
@@ -156,7 +156,7 @@ func TestNewTopology(t *testing.T) {
 				segments: []*segment{
 					{
 						allowedIPs:          []*net.IPNet{nodes["a"].Subnet, nodes["a"].InternalIP, {IP: w1, Mask: net.CIDRMask(32, 32)}},
-						endpoint:            nodes["a"].ExternalIP.IP,
+						endpoint:            nodes["a"].Endpoint,
 						key:                 nodes["a"].Key,
 						location:            nodes["a"].Location,
 						cidrs:               []*net.IPNet{nodes["a"].Subnet},
@@ -167,7 +167,7 @@ func TestNewTopology(t *testing.T) {
 					},
 					{
 						allowedIPs:  []*net.IPNet{nodes["b"].Subnet, nodes["b"].InternalIP, nodes["c"].Subnet, nodes["c"].InternalIP, {IP: w2, Mask: net.CIDRMask(32, 32)}},
-						endpoint:    nodes["b"].ExternalIP.IP,
+						endpoint:    nodes["b"].Endpoint,
 						key:         nodes["b"].Key,
 						location:    nodes["b"].Location,
 						cidrs:       []*net.IPNet{nodes["b"].Subnet, nodes["c"].Subnet},
@@ -193,7 +193,7 @@ func TestNewTopology(t *testing.T) {
 				segments: []*segment{
 					{
 						allowedIPs:          []*net.IPNet{nodes["a"].Subnet, nodes["a"].InternalIP, {IP: w1, Mask: net.CIDRMask(32, 32)}},
-						endpoint:            nodes["a"].ExternalIP.IP,
+						endpoint:            nodes["a"].Endpoint,
 						key:                 nodes["a"].Key,
 						location:            nodes["a"].Location,
 						cidrs:               []*net.IPNet{nodes["a"].Subnet},
@@ -204,7 +204,7 @@ func TestNewTopology(t *testing.T) {
 					},
 					{
 						allowedIPs:  []*net.IPNet{nodes["b"].Subnet, nodes["b"].InternalIP, nodes["c"].Subnet, nodes["c"].InternalIP, {IP: w2, Mask: net.CIDRMask(32, 32)}},
-						endpoint:    nodes["b"].ExternalIP.IP,
+						endpoint:    nodes["b"].Endpoint,
 						key:         nodes["b"].Key,
 						location:    nodes["b"].Location,
 						cidrs:       []*net.IPNet{nodes["b"].Subnet, nodes["c"].Subnet},
@@ -230,7 +230,7 @@ func TestNewTopology(t *testing.T) {
 				segments: []*segment{
 					{
 						allowedIPs:          []*net.IPNet{nodes["a"].Subnet, nodes["a"].InternalIP, {IP: w1, Mask: net.CIDRMask(32, 32)}},
-						endpoint:            nodes["a"].ExternalIP.IP,
+						endpoint:            nodes["a"].Endpoint,
 						key:                 nodes["a"].Key,
 						location:            nodes["a"].Name,
 						cidrs:               []*net.IPNet{nodes["a"].Subnet},
@@ -241,7 +241,7 @@ func TestNewTopology(t *testing.T) {
 					},
 					{
 						allowedIPs:  []*net.IPNet{nodes["b"].Subnet, nodes["b"].InternalIP, {IP: w2, Mask: net.CIDRMask(32, 32)}},
-						endpoint:    nodes["b"].ExternalIP.IP,
+						endpoint:    nodes["b"].Endpoint,
 						key:         nodes["b"].Key,
 						location:    nodes["b"].Name,
 						cidrs:       []*net.IPNet{nodes["b"].Subnet},
@@ -251,7 +251,7 @@ func TestNewTopology(t *testing.T) {
 					},
 					{
 						allowedIPs:  []*net.IPNet{nodes["c"].Subnet, nodes["c"].InternalIP, {IP: w3, Mask: net.CIDRMask(32, 32)}},
-						endpoint:    nodes["c"].ExternalIP.IP,
+						endpoint:    nodes["c"].Endpoint,
 						key:         nodes["c"].Key,
 						location:    nodes["c"].Name,
 						cidrs:       []*net.IPNet{nodes["c"].Subnet},
@@ -277,7 +277,7 @@ func TestNewTopology(t *testing.T) {
 				segments: []*segment{
 					{
 						allowedIPs:          []*net.IPNet{nodes["a"].Subnet, nodes["a"].InternalIP, {IP: w1, Mask: net.CIDRMask(32, 32)}},
-						endpoint:            nodes["a"].ExternalIP.IP,
+						endpoint:            nodes["a"].Endpoint,
 						key:                 nodes["a"].Key,
 						location:            nodes["a"].Name,
 						cidrs:               []*net.IPNet{nodes["a"].Subnet},
@@ -288,7 +288,7 @@ func TestNewTopology(t *testing.T) {
 					},
 					{
 						allowedIPs:  []*net.IPNet{nodes["b"].Subnet, nodes["b"].InternalIP, {IP: w2, Mask: net.CIDRMask(32, 32)}},
-						endpoint:    nodes["b"].ExternalIP.IP,
+						endpoint:    nodes["b"].Endpoint,
 						key:         nodes["b"].Key,
 						location:    nodes["b"].Name,
 						cidrs:       []*net.IPNet{nodes["b"].Subnet},
@@ -298,7 +298,7 @@ func TestNewTopology(t *testing.T) {
 					},
 					{
 						allowedIPs:  []*net.IPNet{nodes["c"].Subnet, nodes["c"].InternalIP, {IP: w3, Mask: net.CIDRMask(32, 32)}},
-						endpoint:    nodes["c"].ExternalIP.IP,
+						endpoint:    nodes["c"].Endpoint,
 						key:         nodes["c"].Key,
 						location:    nodes["c"].Name,
 						cidrs:       []*net.IPNet{nodes["c"].Subnet},
@@ -324,7 +324,7 @@ func TestNewTopology(t *testing.T) {
 				segments: []*segment{
 					{
 						allowedIPs:          []*net.IPNet{nodes["a"].Subnet, nodes["a"].InternalIP, {IP: w1, Mask: net.CIDRMask(32, 32)}},
-						endpoint:            nodes["a"].ExternalIP.IP,
+						endpoint:            nodes["a"].Endpoint,
 						key:                 nodes["a"].Key,
 						location:            nodes["a"].Name,
 						cidrs:               []*net.IPNet{nodes["a"].Subnet},
@@ -335,7 +335,7 @@ func TestNewTopology(t *testing.T) {
 					},
 					{
 						allowedIPs:  []*net.IPNet{nodes["b"].Subnet, nodes["b"].InternalIP, {IP: w2, Mask: net.CIDRMask(32, 32)}},
-						endpoint:    nodes["b"].ExternalIP.IP,
+						endpoint:    nodes["b"].Endpoint,
 						key:         nodes["b"].Key,
 						location:    nodes["b"].Name,
 						cidrs:       []*net.IPNet{nodes["b"].Subnet},
@@ -345,7 +345,7 @@ func TestNewTopology(t *testing.T) {
 					},
 					{
 						allowedIPs:  []*net.IPNet{nodes["c"].Subnet, nodes["c"].InternalIP, {IP: w3, Mask: net.CIDRMask(32, 32)}},
-						endpoint:    nodes["c"].ExternalIP.IP,
+						endpoint:    nodes["c"].Endpoint,
 						key:         nodes["c"].Key,
 						location:    nodes["c"].Name,
 						cidrs:       []*net.IPNet{nodes["c"].Subnet},
@@ -1400,26 +1400,26 @@ func TestFindLeader(t *testing.T) {
 
 	nodes := []*Node{
 		{
-			Name:       "a",
-			ExternalIP: e1,
+			Name:     "a",
+			Endpoint: &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{IP: e1.IP}, Port: DefaultKiloPort},
 		},
 		{
-			Name:       "b",
-			ExternalIP: e2,
+			Name:     "b",
+			Endpoint: &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{IP: e2.IP}, Port: DefaultKiloPort},
 		},
 		{
-			Name:       "c",
-			ExternalIP: e2,
+			Name:     "c",
+			Endpoint: &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{IP: e2.IP}, Port: DefaultKiloPort},
 		},
 		{
-			Name:       "d",
-			ExternalIP: e1,
-			Leader:     true,
+			Name:     "d",
+			Endpoint: &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{IP: e1.IP}, Port: DefaultKiloPort},
+			Leader:   true,
 		},
 		{
-			Name:       "2",
-			ExternalIP: e2,
-			Leader:     true,
+			Name:     "2",
+			Endpoint: &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{IP: e2.IP}, Port: DefaultKiloPort},
+			Leader:   true,
 		},
 	}
 	for _, tc := range []struct {

--- a/pkg/wireguard/conf_test.go
+++ b/pkg/wireguard/conf_test.go
@@ -96,6 +96,28 @@ func TestCompareConf(t *testing.T) {
 			out: false,
 		},
 		{
+			name: "different value",
+			a: []byte(`[Interface]
+		PrivateKey = private
+		ListenPort = 51820
+
+		[Peer]
+		Endpoint = 10.1.0.2:51820
+		PublicKey = key
+		AllowedIPs = 10.2.2.0/24, 192.168.0.1/32, 10.2.3.0/24, 192.168.0.2/32, 10.4.0.2/32
+		`),
+			b: []byte(`[Interface]
+		PrivateKey = private
+		ListenPort = 51820
+
+		[Peer]
+		Endpoint = 10.1.0.2:51820
+		PublicKey = key2
+		AllowedIPs = 10.2.2.0/24, 192.168.0.1/32, 10.2.3.0/24, 192.168.0.2/32, 10.4.0.2/32
+		`),
+			out: false,
+		},
+		{
 			name: "section order",
 			a: []byte(`[Interface]
 		PrivateKey = private


### PR DESCRIPTION
This commit allows DNS names to be used when specifying the endpoint
for a node in the WireGuard mesh. This is useful in many scenarios, in
particular when operating an IoT device whose public IP is dynamic. This
change allows the administrator to use a dynamic DNS name in the node's
endpoint.

One of the side-effects of this change is that the WireGuard port can
now be specified individually for each node in the mesh, if the
administrator wishes to do so.

*Note*: this commit introduces a breaking change; the
`force-external-ip` node annotation has been removed; its functionality
has been ported over to the `force-endpoint` annotation. This annotation
is documented in the annotations.md file. The expected content of this
annotation is no longer a CIDR but rather a host:port. The host can be
either a DNS name or an IP.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

fixes: https://github.com/squat/kilo/issues/24