### PR TITLE
ignoring endpoint check when persistent keepalive is not zero

### DIFF
--- a/pkg/wireguard/conf.go
+++ b/pkg/wireguard/conf.go
@@ -302,7 +302,7 @@ func (c *Conf) Equal(b *Conf) bool {
 		if (c.Peers[i].Endpoint == nil) != (b.Peers[i].Endpoint == nil) {
 			return false
 		}
-		if c.Peers[i].Endpoint != nil {
+		if c.Peers[i].Endpoint != nil && c.Peers[i].PersistentKeepalive == 0 {
 			if c.Peers[i].Endpoint.Port != b.Peers[i].Endpoint.Port {
 				return false
 			}


### PR DESCRIPTION
According to #34 