### PR TITLE
docs/vpn: document vpn as internet gateway

### DIFF
--- a/docs/vpn-server.md
+++ b/docs/vpn-server.md
@@ -1,0 +1,56 @@
+# VPN Server
+
+The cluster VPN created by Kilo can also be used by peers as a gateway to access the Internet.
+In order configure a local machine to use the cluster VPN as a gateway to the Internet, first register the local machine as a peer of the cluster following the steps in the [VPN docs](./vpn.md).
+
+Once the machine is registered, generate the configuration for the local peer:
+
+```shell
+PEER=squat # name of the registered peer
+kgctl showconf peer $PEER > peer.ini
+```
+
+Next, the WireGuard configuration must be modified to enable routing traffic for any IP via a node in the cluster.
+To do so, open the WireGuard configuration in an editor, select a node in the cluster, and set the `AllowedIPs` field of that node's corresponding `peer` section to `0.0.0.0/0, ::/0`:
+
+```shell
+$EDITOR peer.ini
+```
+
+The configuration should now look something like:
+
+```ini
+[Peer]
+PublicKey = 2/xU029dz/WtvMZAbnSzmhicl8U1/Y3NYmunRr8EJ0Q=
+AllowedIPs = 0.0.0.0/0, ::/0
+Endpoint = 108.61.142.123:51820
+```
+
+The configuration can then be applied to the local WireGuard interface, e.g. `wg0`:
+
+```shell
+IFACE=wg0
+sudo wg setconf $IFACE peer.ini
+```
+
+Next, add routes for the public IPs of the WireGuard peers to ensure that the packets encapsulated by WireGuard are sent through a real interface:
+
+```shell
+default=$(ip route list all | grep default | awk '{$1=""; print $0}')
+for ip in $(sudo wg | grep endpoint | awk '{print $2}' | sed 's/\(.\+\):[0-9]\+/\1/'); do
+    sudo ip route add $ip $default
+done
+```
+
+Finally, the local machine can be configured to use the WireGuard interface as the device for the default route:
+
+```shell
+sudo ip route delete default
+sudo ip route add default dev $IFACE
+```
+
+The local machine is now using the selected node as its Internet gateway and the connection can be verified.
+For example, try finding the local machine's external IP address:
+```shell
+curl https://icanhazip.com
+```

--- a/docs/vpn.md
+++ b/docs/vpn.md
@@ -64,7 +64,7 @@ Once the routes are in place, the connection to the cluster can be tested.
 For example, try connecting to the API server:
 
 ```shell
-curl -k https://10.0.27.179:6443
+curl -k https://$(kubectl get endpoints kubernetes | tail -n +2 | tr , \\t | awk '{print $2}')
 ```
 
 Likewise, the cluster now also has layer 3 access to the newly added peer.
@@ -105,3 +105,5 @@ EOF
 ```
 
 [See the multi-cluster services docs for more details on connecting clusters to external services](./multi-cluster-services.md).
+
+Although it is not a primary goal of the project, the VPN created by Kilo can also be [used by peers as a gateway to the Internet; for more details, see the VPN server docs](./vpn-server.md).


### PR DESCRIPTION
This commit introduces a new document explaining how peers can use the
Kilo cluster VPN as a gateway to the internet.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

Fixes: #40