### PR TITLE
Add a Dockerfile for kgctl

### DIFF
--- a/Dockerfile-kgctl
+++ b/Dockerfile-kgctl
@@ -1,0 +1,9 @@
+FROM golang:1.14.2-alpine3.11 as builder
+WORKDIR /build
+COPY . .
+RUN go build -o /kgctl cmd/kgctl/*
+
+FROM alpine:3.11
+ENV KUBECONFIG /config
+COPY --from=builder /kgctl /kgctl
+ENTRYPOINT ["/kgctl"]


### PR DESCRIPTION
This makes it easier to build a simple Docker container for using kgctl. This is essential for MacOS users as kgctl doesn't currently compile on it.