### PR TITLE
Add warning not to remove the persistentKeepalive

### DIFF
--- a/docs/vpn.md
+++ b/docs/vpn.md
@@ -21,6 +21,8 @@ spec:
   persistentKeepalive: 10
 ```
 
+:warning: You *MUST* include a `persistentKeepalive` value, though it can be any positive integer value.
+
 Then, apply the resource to the cluster:
 
 ```shell


### PR DESCRIPTION
Contrary to normal wireguard configuration, kilo requires a
persistentKeepalive and strange behaviour ensues if there is not
one present

Signed-off-by: Anton Melser <anton@melser.org>