### PR TITLE
pkg/mesh/graph.go: use WireGuard CIDR as title

### DIFF
--- a/pkg/mesh/graph.go
+++ b/pkg/mesh/graph.go
@@ -27,7 +27,7 @@ import (
 func (t *Topology) Dot() (string, error) {
 	g := gographviz.NewGraph()
 	g.Name = "kilo"
-	if err := g.AddAttr("kilo", string(gographviz.Label), graphEscape(t.subnet.String())); err != nil {
+	if err := g.AddAttr("kilo", string(gographviz.Label), graphEscape(t.wireGuardCIDR.String())); err != nil {
 		return "", fmt.Errorf("failed to add label to graph")
 	}
 	if err := g.AddAttr("kilo", string(gographviz.LabelLOC), "t"); err != nil {


### PR DESCRIPTION
This commit changes the graph so that the WireGuard CIDR is used as the
title rather than the pod subnet assigned to a node in the cluster.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @leonnicolas 