### PR TITLE
pkg/mesh: don't shadow privIface

### DIFF
--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -131,7 +131,7 @@ func New(backend Backend, enc encapsulation.Encapsulator, granularity Granularit
 		if err != nil {
 			return nil, fmt.Errorf("failed to find interface for private IP: %v", err)
 		}
-		privIface := ifaces[0].Index
+		privIface = ifaces[0].Index
 		if enc.Strategy() != encapsulation.Never {
 			if err := enc.Init(privIface); err != nil {
 				return nil, fmt.Errorf("failed to initialize encapsulator: %v", err)


### PR DESCRIPTION
This commit fixes a bug where the variable holding the index of the
private interface was shadowed, causing it to always be "0".

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @leonnicolas 