### PR TITLE
Vulnerability: Don't add generic ACCEPT rules to the filter chain

### DIFF
--- a/pkg/mesh/routes.go
+++ b/pkg/mesh/routes.go
@@ -226,8 +226,6 @@ func (t *Topology) Rules(cni bool) []iptables.Rule {
 	rules = append(rules, iptables.NewIPv6Chain("nat", "KILO-NAT"))
 	if cni {
 		rules = append(rules, iptables.NewRule(iptables.GetProtocol(len(t.subnet.IP)), "nat", "POSTROUTING", "-m", "comment", "--comment", "Kilo: jump to KILO-NAT chain", "-s", t.subnet.String(), "-j", "KILO-NAT"))
-		rules = append(rules, iptables.NewRule(iptables.GetProtocol(len(t.subnet.IP)), "filter", "FORWARD", "-m", "comment", "--comment", "Kilo: forward packets from the pod subnet", "-s", t.subnet.String(), "-j", "ACCEPT"))
-		rules = append(rules, iptables.NewRule(iptables.GetProtocol(len(t.subnet.IP)), "filter", "FORWARD", "-m", "comment", "--comment", "Kilo: forward packets to the pod subnet", "-d", t.subnet.String(), "-j", "ACCEPT"))
 	}
 	for _, s := range t.segments {
 		rules = append(rules, iptables.NewRule(iptables.GetProtocol(len(s.wireGuardIP)), "nat", "KILO-NAT", "-m", "comment", "--comment", "Kilo: do not NAT packets destined for WireGuared IPs", "-d", s.wireGuardIP.String(), "-j", "RETURN"))


### PR DESCRIPTION
#106 added these rules under the assumption that Kilo should automatically allow traffic going from/to the pods.

What this actually did was break all firewalls that are "accept explicit, drop implicit" style and allow all traffic through the firewall.

If a user has configured their firewall to be drop by default, they should add rules like these manually if they want to allow all traffic.

This also breaks network policy controllers that are written/configured this way.