### PR TITLE
WIP: add worksInKubernetesCluster flag

### DIFF
--- a/cmd/kg/main.go
+++ b/cmd/kg/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/squat/kilo/pkg/encapsulation"
@@ -86,6 +87,7 @@ func Main() error {
 	compatibility := flag.String("compatibility", "", fmt.Sprintf("Should Kilo run in compatibility mode? Possible values: %s", availableCompatibilities))
 	encapsulate := flag.String("encapsulate", string(encapsulation.Always), fmt.Sprintf("When should Kilo encapsulate packets within a location? Possible values: %s", availableEncapsulations))
 	granularity := flag.String("mesh-granularity", string(mesh.LogicalGranularity), fmt.Sprintf("The granularity of the network mesh to create. Possible values: %s", availableGranularities))
+	worksInKubernetesCluster := flag.Bool("worksInKubernetesCluster", false, "use InClusterConfig metod to configure the Kubernetes API client.")
 	kubeconfig := flag.String("kubeconfig", "", "Path to kubeconfig.")
 	hostname := flag.String("hostname", "", "Hostname of the node on which this process is running.")
 	iface := flag.String("interface", mesh.DefaultKiloInterface, "Name of the Kilo interface to use; if it does not exist, it will be created.")
@@ -166,7 +168,13 @@ func Main() error {
 	var b mesh.Backend
 	switch *backend {
 	case k8s.Backend:
-		config, err := clientcmd.BuildConfigFromFlags(*master, *kubeconfig)
+		var config *rest.Config
+		var err error
+		if *worksInKubernetesCluster {
+			config, err = rest.InClusterConfig()
+		} else {
+			config, err = clientcmd.BuildConfigFromFlags(*master, *kubeconfig)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to create Kubernetes config: %v", err)
 		}

--- a/cmd/kg/main.go
+++ b/cmd/kg/main.go
@@ -87,7 +87,7 @@ func Main() error {
 	compatibility := flag.String("compatibility", "", fmt.Sprintf("Should Kilo run in compatibility mode? Possible values: %s", availableCompatibilities))
 	encapsulate := flag.String("encapsulate", string(encapsulation.Always), fmt.Sprintf("When should Kilo encapsulate packets within a location? Possible values: %s", availableEncapsulations))
 	granularity := flag.String("mesh-granularity", string(mesh.LogicalGranularity), fmt.Sprintf("The granularity of the network mesh to create. Possible values: %s", availableGranularities))
-	worksInKubernetesCluster := flag.Bool("worksInKubernetesCluster", false, "use InClusterConfig metod to configure the Kubernetes API client.")
+	worksInKubernetesCluster := flag.Bool("worksInKubernetesCluster", true, "Set to true if run kilo in Kubernetes cluster.")
 	kubeconfig := flag.String("kubeconfig", "", "Path to kubeconfig.")
 	hostname := flag.String("hostname", "", "Hostname of the node on which this process is running.")
 	iface := flag.String("interface", mesh.DefaultKiloInterface, "Name of the Kilo interface to use; if it does not exist, it will be created.")

--- a/cmd/kg/main.go
+++ b/cmd/kg/main.go
@@ -87,7 +87,7 @@ func Main() error {
 	compatibility := flag.String("compatibility", "", fmt.Sprintf("Should Kilo run in compatibility mode? Possible values: %s", availableCompatibilities))
 	encapsulate := flag.String("encapsulate", string(encapsulation.Always), fmt.Sprintf("When should Kilo encapsulate packets within a location? Possible values: %s", availableEncapsulations))
 	granularity := flag.String("mesh-granularity", string(mesh.LogicalGranularity), fmt.Sprintf("The granularity of the network mesh to create. Possible values: %s", availableGranularities))
-	worksInKubernetesCluster := flag.Bool("worksInKubernetesCluster", true, "Set to true if run kilo in Kubernetes cluster.")
+	worksInKubernetesCluster := flag.Bool("worksInKubernetesCluster", true, "Set to false if run kilo outside Kubernetes cluster.")
 	kubeconfig := flag.String("kubeconfig", "", "Path to kubeconfig.")
 	hostname := flag.String("hostname", "", "Hostname of the node on which this process is running.")
 	iface := flag.String("interface", mesh.DefaultKiloInterface, "Name of the Kilo interface to use; if it does not exist, it will be created.")

--- a/docs/kg.md
+++ b/docs/kg.md
@@ -38,7 +38,7 @@ Usage of bin/amd64/kg:
   -kubeconfig string
     	Path to kubeconfig.
   -worksInKubernetesCluster bool
-      Set to true if run kilo in Kubernetes cluster. (default true)
+      Set to false if run kilo outside Kubernetes cluster. (default true)
   -listen string
     	The address at which to listen for health and metrics. (default ":1107")
   -local

--- a/docs/kg.md
+++ b/docs/kg.md
@@ -37,6 +37,8 @@ Usage of bin/amd64/kg:
     	Name of the Kilo interface to use; if it does not exist, it will be created. (default "kilo0")
   -kubeconfig string
     	Path to kubeconfig.
+  -worksInKubernetesCluster bool
+      Set to true if run kilo in Kubernetes cluster. (default true)
   -listen string
     	The address at which to listen for health and metrics. (default ":1107")
   -local


### PR DESCRIPTION
Hey! I added the `worksInKubernetesCluster` flag so that the pod environment can be used to access the Kubernetes API, if the kilo is running inside the Kubernetes cluster.

Also, I think you can correct the manifests, because now there will be no difference between kubeadm/k3s/etc