### PR TITLE
pkg/mesh/mesh.go: iptables rules in encapsulation

### DIFF
--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -490,7 +490,10 @@ func (m *Mesh) applyTopology() {
 	if m.enc.Strategy() != encapsulation.Never && m.local {
 		var cidrs []*net.IPNet
 		for _, s := range t.segments {
-			if s.location == nodes[m.hostname].Location {
+			// If the location prefix is not logicalLocation, but nodeLocation,
+			// we don't need to set any extra rules for encapsulation anyways
+			// because traffic will go over WireGuard.
+			if s.location == logicalLocationPrefix+nodes[m.hostname].Location {
 				for i := range s.privateIPs {
 					cidrs = append(cidrs, oneAddressCIDR(s.privateIPs[i]))
 				}


### PR DESCRIPTION
Because of new naming conventions for locations, the CIDRs were not
being set within locations.
This lead to no iptables rules added for nodes in the same location.