### PR TITLE
MAINTAINERS.md: propose @leonnicolas as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,6 @@
+# Core Maintainers of This Repository
+
+| Name               | GitHub                                         |
+|--------------------|------------------------------------------------|
+| Lucas Servén Marín | [@squat](https://github.com/squat)             |
+| Leon Löchner       | [@leonnicolas](https://github.com/leonnicolas) |


### PR DESCRIPTION
This commit proposes [Leon](https://github.com/leonnicolas) as a
maintainer of Kilo. Leon has done tons of great work in the project in
feature development, bug triaging, and documentation. It would be a
privilege to have you join!

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @leonnicolas :whale: 