### PR TITLE
docs: remove use of 'simply'

### DIFF
--- a/docs/kgctl.md
+++ b/docs/kgctl.md
@@ -8,7 +8,7 @@ This tool can be used to understand a mesh's topology, get the WireGuard configu
 
 Installing `kgctl` currently requires building the binary from source.
 *Note*: the [Go toolchain must be installed](https://golang.org/doc/install) in order to build the binary.
-To build and install `kgctl`, simply run:
+To build and install `kgctl`, run:
 
 ```shell
 go install github.com/squat/kilo/cmd/kgctl


### PR DESCRIPTION
Let's make the documentation more inclusive and sensitive of the
familiarity and comfort of users.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>