### PR TITLE
FEATURE: allow disabling private IPs

### DIFF
--- a/pkg/k8s/backend.go
+++ b/pkg/k8s/backend.go
@@ -271,6 +271,12 @@ func translateNode(node *v1.Node, topologyLabel string) *mesh.Node {
 	if internalIP == nil {
 		internalIP = normalizeIP(node.ObjectMeta.Annotations[internalIPAnnotationKey])
 	}
+	// Set the ForceInternalIP flag, if force-internal-ip annotation was set to "".
+	noInternalIP := false
+	if s, ok := node.ObjectMeta.Annotations[forceInternalIPAnnotationKey]; ok && (s == "" || s == "-") {
+		noInternalIP = true
+		internalIP = nil
+	}
 	// Set Wireguard PersistentKeepalive setting for the node.
 	var persistentKeepalive int64
 	if keepAlive, ok := node.ObjectMeta.Annotations[persistentKeepaliveKey]; !ok {
@@ -296,6 +302,7 @@ func translateNode(node *v1.Node, topologyLabel string) *mesh.Node {
 		// It is valid for the InternalIP to be nil,
 		// if the given node only has public IP addresses.
 		Endpoint:            endpoint,
+		NoInternalIP:        noInternalIP,
 		InternalIP:          internalIP,
 		Key:                 []byte(node.ObjectMeta.Annotations[keyAnnotationKey]),
 		LastSeen:            lastSeen,

--- a/pkg/k8s/backend_test.go
+++ b/pkg/k8s/backend_test.go
@@ -137,7 +137,8 @@ func TestTranslateNode(t *testing.T) {
 				forceInternalIPAnnotationKey: "-10.1.0.2/24",
 			},
 			out: &mesh.Node{
-				InternalIP: &net.IPNet{IP: net.ParseIP("10.1.0.1"), Mask: net.CIDRMask(24, 32)},
+				InternalIP:   &net.IPNet{IP: net.ParseIP("10.1.0.1"), Mask: net.CIDRMask(24, 32)},
+				NoInternalIP: false,
 			},
 		},
 		{
@@ -147,7 +148,8 @@ func TestTranslateNode(t *testing.T) {
 				forceInternalIPAnnotationKey: "10.1.0.2/24",
 			},
 			out: &mesh.Node{
-				InternalIP: &net.IPNet{IP: net.ParseIP("10.1.0.2"), Mask: net.CIDRMask(24, 32)},
+				InternalIP:   &net.IPNet{IP: net.ParseIP("10.1.0.2"), Mask: net.CIDRMask(24, 32)},
+				NoInternalIP: false,
 			},
 		},
 		{
@@ -176,6 +178,7 @@ func TestTranslateNode(t *testing.T) {
 			},
 			out: &mesh.Node{
 				Endpoint:            &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{IP: net.ParseIP("10.0.0.2")}, Port: 51821},
+				NoInternalIP:        false,
 				InternalIP:          &net.IPNet{IP: net.ParseIP("10.1.0.2"), Mask: net.CIDRMask(32, 32)},
 				Key:                 []byte("foo"),
 				LastSeen:            1000000000,
@@ -203,6 +206,35 @@ func TestTranslateNode(t *testing.T) {
 			},
 			out: &mesh.Node{
 				Endpoint:            &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{IP: net.ParseIP("10.0.0.1")}, Port: 51820},
+				InternalIP:          nil,
+				Key:                 []byte("foo"),
+				LastSeen:            1000000000,
+				Leader:              false,
+				Location:            "b",
+				PersistentKeepalive: 25,
+				Subnet:              &net.IPNet{IP: net.ParseIP("10.2.1.0"), Mask: net.CIDRMask(24, 32)},
+				WireGuardIP:         &net.IPNet{IP: net.ParseIP("10.4.0.1"), Mask: net.CIDRMask(16, 32)},
+			},
+			subnet: "10.2.1.0/24",
+		},
+		{
+			name: "Force no internal IP",
+			annotations: map[string]string{
+				endpointAnnotationKey:        "10.0.0.1:51820",
+				internalIPAnnotationKey:      "10.1.0.1/32",
+				forceInternalIPAnnotationKey: "",
+				keyAnnotationKey:             "foo",
+				lastSeenAnnotationKey:        "1000000000",
+				locationAnnotationKey:        "b",
+				persistentKeepaliveKey:       "25",
+				wireGuardIPAnnotationKey:     "10.4.0.1/16",
+			},
+			labels: map[string]string{
+				RegionLabelKey: "a",
+			},
+			out: &mesh.Node{
+				Endpoint:            &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{IP: net.ParseIP("10.0.0.1")}, Port: 51820},
+				NoInternalIP:        true,
 				InternalIP:          nil,
 				Key:                 []byte("foo"),
 				LastSeen:            1000000000,

--- a/pkg/mesh/backend.go
+++ b/pkg/mesh/backend.go
@@ -51,9 +51,10 @@ const (
 
 // Node represents a node in the network.
 type Node struct {
-	Endpoint   *wireguard.Endpoint
-	Key        []byte
-	InternalIP *net.IPNet
+	Endpoint     *wireguard.Endpoint
+	Key          []byte
+	NoInternalIP bool
+	InternalIP   *net.IPNet
 	// LastSeen is a Unix time for the last time
 	// the node confirmed it was live.
 	LastSeen int64

--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -371,7 +371,7 @@ func (m *Mesh) handleLocal(n *Node) {
 	if n.Endpoint == nil || (n.Endpoint.DNS == "" && n.Endpoint.IP == nil) {
 		n.Endpoint = &wireguard.Endpoint{DNSOrIP: wireguard.DNSOrIP{IP: m.externalIP.IP}, Port: m.port}
 	}
-	if n.InternalIP == nil {
+	if n.InternalIP == nil && !n.NoInternalIP {
 		n.InternalIP = m.internalIP
 	}
 	// Compare the given node to the calculated local node.
@@ -380,6 +380,7 @@ func (m *Mesh) handleLocal(n *Node) {
 	local := &Node{
 		Endpoint:            n.Endpoint,
 		Key:                 m.pub,
+		NoInternalIP:        n.NoInternalIP,
 		InternalIP:          n.InternalIP,
 		LastSeen:            time.Now().Unix(),
 		Leader:              n.Leader,

--- a/pkg/mesh/topology.go
+++ b/pkg/mesh/topology.go
@@ -83,6 +83,8 @@ func NewTopology(nodes map[string]*Node, peers map[string]*Peer, granularity Gra
 		switch granularity {
 		case LogicalGranularity:
 			location = logicalLocationPrefix + node.Location
+			// Put node in a different location, if no private
+			// IP was found.
 			if node.InternalIP == nil {
 				location = nodeLocationPrefix + node.Name
 			}


### PR DESCRIPTION
When forcing the internal IP to "" or "-" with the force-internal-ip annotation, private IPs won't be used.

Nodes that have the annotation will be put in their own location: e.g.: "node:node-name". Then they will try to use WireGuard to connect to other nodes' endpoints in the cluster over their public interface. This only works, if the kubelet of the respected nodes can still connect to the API server over a public endpoint. If the kubelet uses a private IP to connect to the API server, Kilo will create routes so that the kubelet's request to the API server will go over the WireGuard interface. This leading to the node being  not ready, if the API server's node has not set up the WireGurad config correctly. Anyways, trying to encrypt API server communication over Kilo's WireGuard sounds like a hen egg problem.
 
@SerialVelocity I don't have any device with a private and public interface. Could you test this?