### PR TITLE
manifests: fix kubeadm CNI path

### DIFF
--- a/manifests/kilo-kubeadm.yaml
+++ b/manifests/kilo-kubeadm.yaml
@@ -160,7 +160,7 @@ spec:
           path: /opt/cni/bin
       - name: cni-conf-dir
         hostPath:
-          path: /etc/kubernetes/cni/net.d
+          path: /etc/cni/net.d
       - name: kilo-dir
         hostPath:
           path: /var/lib/kilo


### PR DESCRIPTION
As discussed in
https://github.com/squat/kilo/issues/129#issuecomment-789651850,
the Kilo manifests for kubeadm install the CNI configuration in the
wrong directory. They are using /etc/kubernetes/cni/net.d [0] when they
should be using /etc/cni/net.d [1].

[0]
https://github.com/squat/kilo/blob/main/manifests/kilo-kubeadm.yaml#L163
[1]
https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#cni

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @leonnicolas 