### PR TITLE
pkg/mesh: correctly idenitfy 172.16/12 IPs

### DIFF
--- a/pkg/mesh/ip.go
+++ b/pkg/mesh/ip.go
@@ -42,12 +42,12 @@ func isLocal(ip net.IP) bool {
 func isPublic(ip net.IP) bool {
 	// Check RFC 1918 addresses.
 	if ip4 := ip.To4(); ip4 != nil {
-		switch true {
+		switch {
 		// Check for 10.0.0.0/8.
 		case ip4[0] == 10:
 			return false
 		// Check for 172.16.0.0/12.
-		case ip4[0] == 172 && ip4[1]&0xf0 == 0x01:
+		case ip4[0] == 172 && ip4[1]&0xf0 != 0:
 			return false
 		// Check for 192.168.0.0/16.
 		case ip4[0] == 192 && ip4[1] == 168:
@@ -58,7 +58,7 @@ func isPublic(ip net.IP) bool {
 	}
 	// Check RFC 4193 addresses.
 	if len(ip) == net.IPv6len {
-		switch true {
+		switch {
 		// Check for fd00::/8.
 		case ip[0] == 0xfd && ip[1] == 0x00:
 			return false

--- a/pkg/mesh/ip_test.go
+++ b/pkg/mesh/ip_test.go
@@ -127,3 +127,41 @@ func TestSortIPs(t *testing.T) {
 		}
 	}
 }
+
+func TestIsPublic(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ip   net.IP
+		out  bool
+	}{
+		{
+			name: "10/8",
+			ip:   net.ParseIP("10.0.0.1"),
+			out:  false,
+		},
+		{
+			name: "172.16/12",
+			ip:   net.ParseIP("172.16.0.0"),
+			out:  false,
+		},
+		{
+			name: "172.16/12 random",
+			ip:   net.ParseIP("172.24.135.46"),
+			out:  false,
+		},
+		{
+			name: "below 172.16/12",
+			ip:   net.ParseIP("172.15.255.255"),
+			out:  true,
+		},
+		{
+			name: "192.168/16",
+			ip:   net.ParseIP("192.168.0.0"),
+			out:  false,
+		},
+	} {
+		if isPublic(tc.ip) != tc.out {
+			t.Errorf("test case %q: expected %t, got %t", tc.name, tc.out, !tc.out)
+		}
+	}
+}


### PR DESCRIPTION
Currently Kilo incorrectly identifies the 172.16/12 private IP range.
This commit fixes the logic.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

Fixes: https://github.com/squat/kilo/issues/57#issuecomment-791450130

cc @leonnicolas 