### PR TITLE
pkg/mesh/mesh.go: actually add resync period

### DIFF
--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -166,6 +166,7 @@ func New(backend Backend, enc encapsulation.Encapsulator, granularity Granularit
 		priv:         private,
 		privIface:    privIface,
 		pub:          public,
+		resyncPeriod: resyncPeriod,
 		local:        local,
 		stop:         make(chan struct{}),
 		subnet:       subnet,


### PR DESCRIPTION
resync period was not added to mesh struct.

fixes #137 

Signed-off-by: leonnicolas <leonloechner@gmx.de>