### PR TITLE
pkg/route: correct route error check

### DIFF
--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -108,14 +108,14 @@ func (t *Table) Run(stop <-chan struct{}) (<-chan error, error) {
 			switch e.Type {
 			// Watch for deleted routes to reconcile this table's routes.
 			case unix.RTM_DELROUTE:
+				// Filter out invalid routes.
+				if e.Route.Dst == nil {
+					continue
+				}
 				t.mu.Lock()
 				for k := range t.rs {
 					switch r := t.rs[k].(type) {
 					case *netlink.Route:
-						// Filter out invalid routes.
-						if r == nil || r.Dst == nil {
-							continue
-						}
 						// If any deleted route's destination matches a destination
 						// in the table, reset the corresponding route just in case.
 						if r.Dst.IP.Equal(e.Route.Dst.IP) && r.Dst.Mask.String() == e.Route.Dst.Mask.String() {


### PR DESCRIPTION
Currently, when the route controller processes updates from netlink, it
checks if the routes in the table are nil or have no destination.
However, we control this and can guarantee that it's never the case.
Instead, we should check if the routes from netlink are valid.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>