### PR TITLE
manifests: declare metrics port

### DIFF
--- a/manifests/kilo-bootkube-flannel.yaml
+++ b/manifests/kilo-bootkube-flannel.yaml
@@ -77,6 +77,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        ports:
+        - containerPort: 1107
+          name: metrics
         securityContext:
           privileged: true
         volumeMounts:

--- a/manifests/kilo-bootkube.yaml
+++ b/manifests/kilo-bootkube.yaml
@@ -108,6 +108,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        ports:
+        - containerPort: 1107
+          name: metrics
         securityContext:
           privileged: true
         volumeMounts:

--- a/manifests/kilo-k3s-flannel.yaml
+++ b/manifests/kilo-k3s-flannel.yaml
@@ -77,6 +77,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        ports:
+        - containerPort: 1107
+          name: metrics
         securityContext:
           privileged: true
         volumeMounts:

--- a/manifests/kilo-k3s-userspace-heterogeneous.yaml
+++ b/manifests/kilo-k3s-userspace-heterogeneous.yaml
@@ -112,6 +112,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        ports:
+        - containerPort: 1107
+          name: metrics
         securityContext:
           privileged: true
         volumeMounts:

--- a/manifests/kilo-k3s-userspace.yaml
+++ b/manifests/kilo-k3s-userspace.yaml
@@ -110,6 +110,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        ports:
+        - containerPort: 1107
+          name: metrics
         securityContext:
           privileged: true
         volumeMounts:

--- a/manifests/kilo-k3s.yaml
+++ b/manifests/kilo-k3s.yaml
@@ -108,6 +108,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        ports:
+        - containerPort: 1107
+          name: metrics
         securityContext:
           privileged: true
         volumeMounts:

--- a/manifests/kilo-kubeadm-flannel.yaml
+++ b/manifests/kilo-kubeadm-flannel.yaml
@@ -77,6 +77,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        ports:
+        - containerPort: 1107
+          name: metrics
         securityContext:
           privileged: true
         volumeMounts:

--- a/manifests/kilo-kubeadm.yaml
+++ b/manifests/kilo-kubeadm.yaml
@@ -108,6 +108,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        ports:
+        - containerPort: 1107
+          name: metrics
         securityContext:
           privileged: true
         volumeMounts:

--- a/manifests/kilo-typhoon-flannel.yaml
+++ b/manifests/kilo-typhoon-flannel.yaml
@@ -77,6 +77,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        ports:
+        - containerPort: 1107
+          name: metrics
         securityContext:
           privileged: true
         volumeMounts:

--- a/manifests/kilo-typhoon.yaml
+++ b/manifests/kilo-typhoon.yaml
@@ -108,6 +108,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        ports:
+        - containerPort: 1107
+          name: metrics
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
This commit ammends all of the Kilo manifests so that the DaemonSets
declare the port they expose.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>