### PR TITLE
Makefile: bump golang toolchain for M1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.7
+        go-version: 1.16.5
     - name: Build
       run: make
 
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.7
+        go-version: 1.16.5
     - name: Build kg and kgctl for all Linux Architectures
       run: make all-build
 
@@ -40,9 +40,11 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.7
-    - name: Build kgctl for Darwin
-      run: make OS=darwin
+        go-version: 1.16.5
+    - name: Build kgctl for Darwin amd64
+      run: make OS=darwin ARCH=amd64
+    - name: Build kgctl for Darwin arm64
+      run: make OS=darwin ARCH=arm64
 
   windows:
     runs-on: ubuntu-latest
@@ -51,7 +53,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.7
+        go-version: 1.16.5
     - name: Build kgctl for Windows
       run: make OS=windows
 
@@ -62,7 +64,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.7
+        go-version: 1.16.5
     - name: Run Unit Tests
       run: make unit
 
@@ -74,7 +76,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.7
+        go-version: 1.16.5
     - name: Run e2e Tests
       run: make e2e
 
@@ -85,7 +87,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.7
+        go-version: 1.16.5
     - name: Lint Code
       run: make lint
 
@@ -96,7 +98,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.7
+        go-version: 1.16.5
     - name: Enable Experimental Docker CLI
       run: |
         echo $'{\n  "experimental": true\n}' | sudo tee /etc/docker/daemon.json
@@ -125,7 +127,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.7
+        go-version: 1.16.5
     - name: Enable Experimental Docker CLI
       run: |
         echo $'{\n  "experimental": true\n}' | sudo tee /etc/docker/daemon.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.7
+        go-version: 1.16.5
     - name: Make Directory with kgctl Binaries to Be Released
       run: make release
     - name: Publish Release

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ export GO111MODULE=on
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)
-ALL_OS := linux darwin windows
 ALL_ARCH := amd64 arm arm64
 DOCKER_ARCH := "amd64" "arm v7" "arm64 v8"
 ifeq ($(OS),linux)
@@ -11,7 +10,7 @@ ifeq ($(OS),linux)
 else
     BINS := bin/$(OS)/$(ARCH)/kgctl
 endif
-RELEASE_BINS := $(addprefix bin/release/kgctl-, $(addprefix linux-, $(ALL_ARCH)) darwin-amd64 windows-amd64)
+RELEASE_BINS := $(addprefix bin/release/kgctl-, $(addprefix linux-, $(ALL_ARCH)) darwin-amd64 darwin-arm64 windows-amd64)
 PROJECT := kilo
 PKG := github.com/squat/$(PROJECT)
 REGISTRY ?= index.docker.io
@@ -44,8 +43,8 @@ KIND_BINARY := $(shell pwd)/bin/kind
 KUBECTL_BINARY := $(shell pwd)/bin/kubectl
 BASH_UNIT := $(shell pwd)/bin/bash_unit
 
-BUILD_IMAGE ?= golang:1.15.7-alpine
-BASE_IMAGE ?= alpine:3.12
+BUILD_IMAGE ?= golang:1.16.5-alpine
+BASE_IMAGE ?= alpine:3.13
 
 build: $(BINS)
 


### PR DESCRIPTION
This commit bumps the Golang toolchain version used to build Kilo to go
1.16 to support builing kgctl for the arm64 M1 macs.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>