### PR TITLE
e2e: refactor the end to end tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ $(KUBECTL_BINARY):
 	chmod +x $@
 
 $(BASH_UNIT):
-	curl -Lo $@ https://raw.githubusercontent.com/pgrange/bash_unit/v1.6.0/bash_unit
+	curl -Lo $@ https://raw.githubusercontent.com/pgrange/bash_unit/v1.7.2/bash_unit
 	chmod +x $@
 
 e2e: container ${KIND_BINARY} ${KUBECTL_BINARY} $(BASH_UNIT)


### PR DESCRIPTION
This commit refactors the e2e tests in the following ways:
* bump the version of `bash_unit` to 1.7.2: the previous version was
from 2018;
* remove the unused `block` function;
* fix the order of `block_unitil_ready_by_name` and `check_ping`: we
should not attempt to interact with pods before they are considered
ready;
* extract the retry logic into a reusable function called `retry`; and
* retry the `check_adjacent` function for robustness.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>