### PR TITLE
cmd/kgctl: improve default kubeconfig

### DIFF
--- a/cmd/kgctl/main.go
+++ b/cmd/kgctl/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -109,7 +110,11 @@ func main() {
 	}
 	cmd.PersistentFlags().StringVar(&backend, "backend", k8s.Backend, fmt.Sprintf("The backend for the mesh. Possible values: %s", availableBackends))
 	cmd.PersistentFlags().StringVar(&granularity, "mesh-granularity", string(mesh.LogicalGranularity), fmt.Sprintf("The granularity of the network mesh to create. Possible values: %s", availableGranularities))
-	cmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", os.Getenv("KUBECONFIG"), "Path to kubeconfig.")
+	defaultKubeconfig := os.Getenv("KUBECONFIG")
+	if _, err := os.Stat(defaultKubeconfig); os.IsNotExist(err) {
+		defaultKubeconfig = filepath.Join(os.Getenv("HOME"), ".kube/config")
+	}
+	cmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", defaultKubeconfig, "Path to kubeconfig.")
 	cmd.PersistentFlags().Uint32Var(&opts.port, "port", mesh.DefaultKiloPort, "The WireGuard port over which the nodes communicate.")
 	cmd.PersistentFlags().StringVar(&topologyLabel, "topology-label", k8s.RegionLabelKey, "Kubernetes node label used to group nodes into logical locations.")
 


### PR DESCRIPTION
This commit adds better handling of the default kubeconfig location in
the kgctl binary for cases where the `$KUBECONFIG` environment variable
is not set. In these cases, kgctl will default to
`$HOME/.kube/config`, putting it in line with tools like `kubectl` and
`kind`.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>