### PR TITLE
e2e: add test for allowed location IPs

### DIFF
--- a/e2e/helper-curl.yaml
+++ b/e2e/helper-curl.yaml
@@ -12,7 +12,6 @@ spec:
       app.kubernetes.io/name: curl
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app.kubernetes.io/name: curl
     spec:


### PR DESCRIPTION
This commit adds a new e2e test fot the recently introduced
allowed-location-ips annotation. This test annotates two nodes with
allowed IPs and then ensures that both of these IPs are reachable from
the curl helper Pod. We need to annotate two nodes because there is a
chance that the curl Pod is scheduled to the annotated node, in which
case we would not test the full functionality.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>