### PR TITLE
.gitignore: ignore e2e kubeconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .push*
 bin/
 tmp/
+e2e/kind.yaml


### PR DESCRIPTION
This commit ensures that the kubeconfig created by kind as part of the
e2e tests is ignored by Git.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>