### PR TITLE
Makefile: fix e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ unit:
 test: lint unit e2e
 
 $(KIND_BINARY):
-	curl -Lo $@ https://kind.sigs.k8s.io/dl/v0.10.0/kind-linux-$(ARCH)
+	curl -Lo $@ https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-$(ARCH)
 	chmod +x $@
 
 $(KUBECTL_BINARY):


### PR DESCRIPTION
We seem to be running into
https://github.com/kubernetes-sigs/kind/issues/2240: kube-proxy is
crashlooping, which in turn causes CoreDNS to fail to connect to the API
server over the Service CIDR, which in turn cases DNS resolution to fail
in the cluster, which in turn causes the e2e tests to fail.
To address this,
this commit bumps the kind version to 0.11.1.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>