### PR TITLE
manifests,e2e: reduce cluster role permissions

### DIFF
--- a/e2e/kilo-kind-userspace.yaml
+++ b/e2e/kilo-kind-userspace.yaml
@@ -57,7 +57,6 @@ rules:
   - peers
   verbs:
   - list
-  - update
   - watch
 - apiGroups:
   - apiextensions.k8s.io

--- a/manifests/kilo-bootkube-flannel.yaml
+++ b/manifests/kilo-bootkube-flannel.yaml
@@ -23,7 +23,6 @@ rules:
   - peers
   verbs:
   - list
-  - update
   - watch
 - apiGroups:
   - apiextensions.k8s.io

--- a/manifests/kilo-bootkube.yaml
+++ b/manifests/kilo-bootkube.yaml
@@ -57,7 +57,6 @@ rules:
   - peers
   verbs:
   - list
-  - update
   - watch
 - apiGroups:
   - apiextensions.k8s.io

--- a/manifests/kilo-k3s-flannel.yaml
+++ b/manifests/kilo-k3s-flannel.yaml
@@ -23,7 +23,6 @@ rules:
   - peers
   verbs:
   - list
-  - update
   - watch
 - apiGroups:
   - apiextensions.k8s.io

--- a/manifests/kilo-k3s-userspace-heterogeneous.yaml
+++ b/manifests/kilo-k3s-userspace-heterogeneous.yaml
@@ -58,7 +58,6 @@ rules:
   - peers
   verbs:
   - list
-  - update
   - watch
 - apiGroups:
   - apiextensions.k8s.io

--- a/manifests/kilo-k3s-userspace.yaml
+++ b/manifests/kilo-k3s-userspace.yaml
@@ -57,7 +57,6 @@ rules:
   - peers
   verbs:
   - list
-  - update
   - watch
 - apiGroups:
   - apiextensions.k8s.io

--- a/manifests/kilo-k3s.yaml
+++ b/manifests/kilo-k3s.yaml
@@ -57,7 +57,6 @@ rules:
   - peers
   verbs:
   - list
-  - update
   - watch
 - apiGroups:
   - apiextensions.k8s.io

--- a/manifests/kilo-kubeadm-flannel.yaml
+++ b/manifests/kilo-kubeadm-flannel.yaml
@@ -23,7 +23,6 @@ rules:
   - peers
   verbs:
   - list
-  - update
   - watch
 - apiGroups:
   - apiextensions.k8s.io

--- a/manifests/kilo-kubeadm.yaml
+++ b/manifests/kilo-kubeadm.yaml
@@ -57,7 +57,6 @@ rules:
   - peers
   verbs:
   - list
-  - update
   - watch
 - apiGroups:
   - apiextensions.k8s.io

--- a/manifests/kilo-typhoon-flannel.yaml
+++ b/manifests/kilo-typhoon-flannel.yaml
@@ -23,7 +23,6 @@ rules:
   - peers
   verbs:
   - list
-  - update
   - watch
 - apiGroups:
   - apiextensions.k8s.io

--- a/manifests/kilo-typhoon.yaml
+++ b/manifests/kilo-typhoon.yaml
@@ -57,7 +57,6 @@ rules:
   - peers
   verbs:
   - list
-  - update
   - watch
 - apiGroups:
   - apiextensions.k8s.io


### PR DESCRIPTION
Since Kilo now uses the `kilo.squat.ai/discovered-endpoints` annotation
for Peer discovery, Kilo no longer needs to update Peer resources, so we
can remove this permission from the ClusterRole. Note, the RBAC in the
manifests is not used today, but we eventually want to migrate to this.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

xref: #210 