### PR TITLE
pkg/wireguard: allow configuring MTU

### DIFF
--- a/cmd/kg/main.go
+++ b/cmd/kg/main.go
@@ -40,6 +40,7 @@ import (
 	kiloclient "github.com/squat/kilo/pkg/k8s/clientset/versioned"
 	"github.com/squat/kilo/pkg/mesh"
 	"github.com/squat/kilo/pkg/version"
+	"github.com/squat/kilo/pkg/wireguard"
 )
 
 const (
@@ -94,6 +95,7 @@ func Main() error {
 	local := flag.Bool("local", true, "Should Kilo manage routes within a location?")
 	logLevel := flag.String("log-level", logLevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", availableLogLevels))
 	master := flag.String("master", "", "The address of the Kubernetes API server (overrides any value in kubeconfig).")
+	mtu := flag.Uint("mtu", wireguard.DefaultMTU, "The MTU of the WireGuard interface created by Kilo.")
 	topologyLabel := flag.String("topology-label", k8s.RegionLabelKey, "Kubernetes node label used to group nodes into logical locations.")
 	var port uint
 	flag.UintVar(&port, "port", mesh.DefaultKiloPort, "The port over which WireGuard peers should communicate.")
@@ -180,7 +182,7 @@ func Main() error {
 		return fmt.Errorf("backend %v unknown; possible values are: %s", *backend, availableBackends)
 	}
 
-	m, err := mesh.New(b, enc, gr, *hostname, uint32(port), s, *local, *cni, *cniPath, *iface, *cleanUpIface, *createIface, *resyncPeriod, log.With(logger, "component", "kilo"))
+	m, err := mesh.New(b, enc, gr, *hostname, uint32(port), s, *local, *cni, *cniPath, *iface, *cleanUpIface, *createIface, *mtu, *resyncPeriod, log.With(logger, "component", "kilo"))
 	if err != nil {
 		return fmt.Errorf("failed to create Kilo mesh: %v", err)
 	}

--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -86,7 +86,7 @@ type Mesh struct {
 }
 
 // New returns a new Mesh instance.
-func New(backend Backend, enc encapsulation.Encapsulator, granularity Granularity, hostname string, port uint32, subnet *net.IPNet, local, cni bool, cniPath, iface string, cleanUpIface bool, createIface bool, resyncPeriod time.Duration, logger log.Logger) (*Mesh, error) {
+func New(backend Backend, enc encapsulation.Encapsulator, granularity Granularity, hostname string, port uint32, subnet *net.IPNet, local, cni bool, cniPath, iface string, cleanUpIface bool, createIface bool, mtu uint, resyncPeriod time.Duration, logger log.Logger) (*Mesh, error) {
 	if err := os.MkdirAll(kiloPath, 0700); err != nil {
 		return nil, fmt.Errorf("failed to create directory to store configuration: %v", err)
 	}
@@ -111,7 +111,7 @@ func New(backend Backend, enc encapsulation.Encapsulator, granularity Granularit
 	}
 	var kiloIface int
 	if createIface {
-		kiloIface, _, err = wireguard.New(iface)
+		kiloIface, _, err = wireguard.New(iface, mtu)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create WireGuard interface: %v", err)
 		}

--- a/pkg/wireguard/wireguard.go
+++ b/pkg/wireguard/wireguard.go
@@ -24,6 +24,9 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+// DefaultMTU is the the default MTU used by WireGuard.
+const DefaultMTU = 1420
+
 type wgLink struct {
 	a netlink.LinkAttrs
 	t string
@@ -41,7 +44,7 @@ func (w wgLink) Type() string {
 // If the interface exists, its index is returned.
 // Otherwise, a new interface is created.
 // The function also returns a boolean to indicate if the interface was created.
-func New(name string) (int, bool, error) {
+func New(name string, mtu uint) (int, bool, error) {
 	link, err := netlink.LinkByName(name)
 	if err == nil {
 		return link.Attrs().Index, false, nil
@@ -51,6 +54,7 @@ func New(name string) (int, bool, error) {
 	}
 	wl := wgLink{a: netlink.NewLinkAttrs(), t: "wireguard"}
 	wl.a.Name = name
+	wl.a.MTU = int(mtu)
 	if err := netlink.LinkAdd(wl); err != nil {
 		return 0, false, fmt.Errorf("failed to create interface %s: %v", name, err)
 	}


### PR DESCRIPTION
This commit makes it possible to configure the MTU for the WireGuard
interface created by Kilo.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

Fixes: #208 