### PR TITLE
e2e/lib.sh: fix namespace of adjacency

### DIFF
--- a/e2e/lib.sh
+++ b/e2e/lib.sh
@@ -135,7 +135,7 @@ create_cluster() {
 	block_until_ready_by_name default curl
 	_kubectl taint node $KIND_CLUSTER-control-plane node-role.kubernetes.io/master:NoSchedule-
 	_kubectl apply -f https://raw.githubusercontent.com/kilo-io/adjacency/main/example.yaml
-	block_until_ready_by_name adjacency adjacency
+	block_until_ready_by_name default adjacency
 }
 
 delete_cluster () {


### PR DESCRIPTION
adjacency is running in the default namespace.
Prior to this commit the block_until_ready function
received the adjacency namespace instead of the default
namespace as a parameter.

Signed-off-by: leonnicolas <leonloechner@gmx.de>