### PR TITLE
pkg/k8s: fix resource scope of Kilo CRD

### DIFF
--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: PeerList
     plural: peers
     singular: peer
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:

--- a/pkg/k8s/apis/kilo/v1alpha1/types.go
+++ b/pkg/k8s/apis/kilo/v1alpha1/types.go
@@ -48,6 +48,7 @@ var PeerShortNames = []string{"peer"}
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:scope=Cluster
 
 // Peer is a WireGuard peer that should have access to the VPN.
 type Peer struct {


### PR DESCRIPTION
When updating Kilo to the latest version of the CustomResourceDefinition
API, the Kilo Peer CRD was incorrectly scoped as a namespaced resource
due to differences in the ergonomics of the tooling.

This commit fixes the scoping of the Peer CRD to be cluster-wide.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>