### PR TITLE
filter local IP addresses when scanning for ips resolved by hostname

### DIFF
--- a/pkg/mesh/discoverips.go
+++ b/pkg/mesh/discoverips.go
@@ -59,6 +59,7 @@ func getIP(hostname string, ignoreIfaces ...int) (*net.IPNet, *net.IPNet, error)
 			ignore[oneAddressCIDR(ip.IP).String()] = struct{}{}
 		}
 	}
+
 	var hostPriv, hostPub []*net.IPNet
 	{
 		// Check IPs to which hostname resolves first.
@@ -69,6 +70,9 @@ func getIP(hostname string, ignoreIfaces ...int) (*net.IPNet, *net.IPNet, error)
 				return nil, nil, fmt.Errorf("failed to search locally assigned addresses: %v", err)
 			}
 			if !ok {
+				continue
+			}
+			if isLocal(ip.IP) {
 				continue
 			}
 			ip.Mask = mask


### PR DESCRIPTION
There are times when the loopback address can show up in the list of public addresses kilo will use to set a node's endpoint

Following on from
https://github.com/squat/kilo/issues/229#issuecomment-903252431