### PR TITLE
cmd/kgctl/main.go: suppress second error message

### DIFF
--- a/cmd/kgctl/main.go
+++ b/cmd/kgctl/main.go
@@ -110,6 +110,7 @@ func main() {
 		Long:              "",
 		PersistentPreRunE: runRoot,
 		Version:           version.Version,
+		SilenceErrors:     true,
 	}
 	cmd.PersistentFlags().StringVar(&backend, "backend", k8s.Backend, fmt.Sprintf("The backend for the mesh. Possible values: %s", availableBackends))
 	cmd.PersistentFlags().StringVar(&granularity, "mesh-granularity", string(mesh.AutoGranularity), fmt.Sprintf("The granularity of the network mesh to create. Possible values: %s", availableGranularities))


### PR DESCRIPTION
`cobra` automatically prints and error if `runE` returns an error.
Since we explicitly print the error, we need to silence cobra.

Signed-off-by: leonnicolas <leonloechner@gmx.de>