### PR TITLE
docs: kgctl binary install on Archlinux

### DIFF
--- a/docs/kgctl.md
+++ b/docs/kgctl.md
@@ -32,7 +32,7 @@ make
 This will produce a `kgctl` binary at `./bin/<your-os>/<your-architecture>/kgctl`.
 
 
-### Binary packages
+### Binary Packages
 
 - Archlinux
 

--- a/docs/kgctl.md
+++ b/docs/kgctl.md
@@ -36,7 +36,7 @@ This will produce a `kgctl` binary at `./bin/<your-os>/<your-architecture>/kgctl
 
 - Archlinux
 
-Install `kgctl` from the Arch User Repository using an AUR helper like `paru` or `yay`
+Install `kgctl` from the Arch User Repository using an AUR helper like `paru` or `yay`:
 
 ```shell
 paru -S kgctl-bin

--- a/docs/kgctl.md
+++ b/docs/kgctl.md
@@ -31,6 +31,17 @@ make
 
 This will produce a `kgctl` binary at `./bin/<your-os>/<your-architecture>/kgctl`.
 
+
+### Binary packages
+
+- Archlinux
+
+Install `kgctl` from the Arch User Repository using an AUR helper like `paru` or `yay`
+
+```shell
+paru -S kgctl-bin
+```
+
 ## Commands
 
 |Command|Syntax|Description|

--- a/docs/kgctl.md
+++ b/docs/kgctl.md
@@ -34,7 +34,7 @@ This will produce a `kgctl` binary at `./bin/<your-os>/<your-architecture>/kgctl
 
 ### Binary Packages
 
-- Archlinux
+#### Arch Linux
 
 Install `kgctl` from the Arch User Repository using an AUR helper like `paru` or `yay`:
 


### PR DESCRIPTION
I've created a package in Arch User Repository for easily installing `kgctl` on Archlinux via an AUR helper like `yay` or `paru`. This internally fetches the binaries from [the GitHub releases page](https://github.com/squat/kilo/releases)

Related Links:
- https://aur.archlinux.org/packages/kgctl-bin
- https://github.com/codingCoffee/PKGBUILDs

Signed-off-by: Ameya Shenoy <shenoy.ameya@gmail.com>