### PR TITLE
pkg/mesh/routes.go: add iptbales forward allow rules for segment.

### DIFF
--- a/pkg/mesh/routes.go
+++ b/pkg/mesh/routes.go
@@ -250,12 +250,12 @@ func (t *Topology) Rules(cni, iptablesForwardRule bool) []iptables.Rule {
 	if cni {
 		rules = append(rules, iptables.NewRule(iptables.GetProtocol(len(t.subnet.IP)), "nat", "POSTROUTING", "-s", t.subnet.String(), "-m", "comment", "--comment", "Kilo: jump to KILO-NAT chain", "-j", "KILO-NAT"))
 		// Some linux distros or docker will set forward DROP in the filter table.
-		// To still be able to have pod to pod communication we need to ALLOW packages from and to pod CIDRs within a location.
-		// Leader nodes will forward packages from all nodes within a location because they act as a gateway for them.
+		// To still be able to have pod to pod communication we need to ALLOW packets from and to pod CIDRs within a location.
+		// Leader nodes will forward packets from all nodes within a location because they act as a gateway for them.
 		// Non leader nodes only need to allow packages from and to their own pod CIDR.
 		if iptablesForwardRule && t.leader {
 			for _, s := range t.segments {
-				if t.location == s.location {
+				if s.location == t.location {
 					// Make sure packets to and from pod cidrs are not dropped in the forward chain.
 					for _, c := range s.cidrs {
 						rules = append(rules, iptables.NewRule(iptables.GetProtocol(len(c.IP)), "filter", "FORWARD", "-m", "comment", "--comment", "Kilo: forward packets from the pod subnet", "-s", c.String(), "-j", "ACCEPT"))

--- a/pkg/mesh/topology.go
+++ b/pkg/mesh/topology.go
@@ -172,6 +172,8 @@ func NewTopology(nodes map[string]*Node, peers map[string]*Peer, granularity Gra
 			privateIPs:          privateIPs,
 			allowedLocationIPs:  allowedLocationIPs,
 		})
+		level.Debug(t.logger).Log("msg", "generated segment", "location", location, "allowedIPs", allowedIPs, "endpoint", topoMap[location][leader].Endpoint, "cidrs", cidrs, "hostnames", hostnames, "leader", leader, "privateIPs", privateIPs, "allowedLocationIPs", allowedLocationIPs)
+
 	}
 	// Sort the Topology segments so the result is stable.
 	sort.Slice(t.segments, func(i, j int) bool {
@@ -218,6 +220,7 @@ func NewTopology(nodes map[string]*Node, peers map[string]*Peer, granularity Gra
 		segment.allowedLocationIPs = t.filterAllowedLocationIPs(segment.allowedLocationIPs, segment.location)
 	}
 
+	level.Debug(t.logger).Log("msg", "generated topology", "location", t.location, "hostname", t.hostname, "wireGuardIP", t.wireGuardCIDR, "privateIP", t.privateIP, "subnet", t.subnet, "leader", t.leader)
 	return &t, nil
 }
 


### PR DESCRIPTION
Before this commit (see #241 and #244) we added the forward ALLOW rule only for the node's
pod CIDR  and not all pod CIDRs of a location. This commit adds the
forward ALLOW rule for packages from (source) and to (destination) all
pod CIDRs of the location if the node is a leader node.

Signed-off-by: leonnicolas <leonloechner@gmx.de>