### PR TITLE
pkg/mesh: fix routes for NATed nodes

### DIFF
--- a/pkg/mesh/routes.go
+++ b/pkg/mesh/routes.go
@@ -40,7 +40,7 @@ func (t *Topology) Routes(kiloIfaceName string, kiloIface, privIface, tunlIface 
 		var gw net.IP
 		for _, segment := range t.segments {
 			if segment.location == t.location {
-				gw = enc.Gw(segment.endpoint.IP(), segment.privateIPs[segment.leader], segment.cidrs[segment.leader])
+				gw = enc.Gw(t.updateEndpoint(segment.endpoint, segment.key, &segment.persistentKeepalive).IP(), segment.privateIPs[segment.leader], segment.cidrs[segment.leader])
 				break
 			}
 		}
@@ -196,7 +196,7 @@ func (t *Topology) Routes(kiloIfaceName string, kiloIface, privIface, tunlIface 
 			// equals the external IP. This means that the node
 			// is only accessible through an external IP and we
 			// cannot encapsulate traffic to an IP through the IP.
-			if segment.privateIPs == nil || segment.privateIPs[i].Equal(segment.endpoint.IP()) {
+			if segment.privateIPs == nil || segment.privateIPs[i].Equal(t.updateEndpoint(segment.endpoint, segment.key, &segment.persistentKeepalive).IP()) {
 				continue
 			}
 			// Add routes to the private IPs of nodes in other segments.


### PR DESCRIPTION
Currently, when a node is behind NAT, it is possible that routes to the
node's private IP address, i.e. routes necessary to communicate with the
Kubelet and any Pods on the host network, will not be created because
the private IP is seen as the same as the location's endpoint and is
thus skipped because trying to encapsulate traffic to the endpoint would
break communiation with the endpoint itself.

This logic is not correct for nodes that are behind NAT, because the
endpoin that the node reports may not be the same as the discovered
endpoint for the location. Instead, we should compare the private IP
address to the discovered endpoint.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>