### PR TITLE
backend: fix Peer persistent keepalive

### DIFF
--- a/pkg/k8s/backend.go
+++ b/pkg/k8s/backend.go
@@ -298,7 +298,7 @@ func translateNode(node *v1.Node, topologyLabel string) *mesh.Node {
 		internalIP = nil
 	}
 	// Set Wireguard PersistentKeepalive setting for the node.
-	var persistentKeepalive = time.Duration(0)
+	var persistentKeepalive time.Duration
 	if keepAlive, ok := node.ObjectMeta.Annotations[persistentKeepaliveKey]; ok {
 		// We can ignore the error, because p will be set to 0 if an error occures.
 		p, _ := strconv.ParseInt(keepAlive, 10, 64)
@@ -414,7 +414,7 @@ func translatePeer(peer *v1alpha1.Peer) *mesh.Peer {
 	}
 	var pka time.Duration
 	if peer.Spec.PersistentKeepalive > 0 {
-		pka = time.Duration(peer.Spec.PersistentKeepalive)
+		pka = time.Duration(peer.Spec.PersistentKeepalive) * time.Second
 	}
 	return &mesh.Peer{
 		Name: peer.Name,
@@ -534,7 +534,7 @@ func (pb *peerBackend) Set(name string, peer *mesh.Peer) error {
 	if peer.PersistentKeepaliveInterval == nil {
 		p.Spec.PersistentKeepalive = 0
 	} else {
-		p.Spec.PersistentKeepalive = int(*peer.PersistentKeepaliveInterval)
+		p.Spec.PersistentKeepalive = int(*peer.PersistentKeepaliveInterval / time.Second)
 	}
 	if peer.PresharedKey == nil {
 		p.Spec.PresharedKey = ""

--- a/pkg/k8s/backend_test.go
+++ b/pkg/k8s/backend_test.go
@@ -511,7 +511,7 @@ func TestTranslatePeer(t *testing.T) {
 		{
 			name: "valid keepalive",
 			spec: v1alpha1.PeerSpec{
-				PersistentKeepalive: 1 * int(time.Second),
+				PersistentKeepalive: 1,
 			},
 			out: &mesh.Peer{
 				Peer: wireguard.Peer{


### PR DESCRIPTION
Right now, the persistent keepalive field of the Peer CRD is always
interpretted as nanoseconds and not seconds. This causes a mismatch
between Kilo's expected behavior and the actual interval that is given
to Peers. Because the interval is interpretted as nanoseconds the value
rounds down to 0 seconds.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>