### PR TITLE
pkg/mesh: respect allowed location IPs in peers

### DIFF
--- a/pkg/mesh/topology.go
+++ b/pkg/mesh/topology.go
@@ -371,7 +371,7 @@ func (t *Topology) PeerConf(name string) *wireguard.Conf {
 	for _, s := range t.segments {
 		peer := wireguard.Peer{
 			PeerConfig: wgtypes.PeerConfig{
-				AllowedIPs:                  s.allowedIPs,
+				AllowedIPs:                  append(s.allowedIPs, s.allowedLocationIPs...),
 				PersistentKeepaliveInterval: pka,
 				PresharedKey:                psk,
 				PublicKey:                   s.key,


### PR DESCRIPTION
Currently, when rendering the configuration for a Peer, the allowed
location configs of any segment are erroneously ignored, meaning that an
administrator will have to manually edit the configuration to get the
expected behavior from a Peer. This commit fixes the generation of the
configuration.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>