### PR TITLE
CI: run for all PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
     tags:
       - "*"
   pull_request:
-    branches: [ main ]
   schedule:
   - cron:  '0 0 * * *'
   workflow_dispatch:


### PR DESCRIPTION
Currently, CI only runs for PRs to the main branch. This commit modifies
the configuration so that it runs for PRs to any branch.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>