### PR TITLE
.github/workflows/release.yaml: clarify job name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ on:
     types: [created]
 name: Handle Release
 jobs:
-  linux:
+  kgctl:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -11,7 +11,7 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.17.1
-    - name: Make Directory with kgctl Binaries to Be Released
+    - name: Build kgctl Binaries to Be Released
       run: make release
     - name: Publish Release
       uses: skx/github-action-publish-binaries@master


### PR DESCRIPTION
Currently,the job to build kgctl binaries is named `linux`, which
suggests to the reader that the job is only building binaries for Linux,
when it is in fact building binaries for Linux, Darwin, and Windows.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
