### PR TITLE
manifests: use CNI 0.4.0

### DIFF
--- a/e2e/kilo-kind-userspace.yaml
+++ b/e2e/kilo-kind-userspace.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.3.1",
+       "cniVersion":"0.4.0",
        "name":"kilo",
        "plugins":[
           {

--- a/manifests/kilo-bootkube.yaml
+++ b/manifests/kilo-bootkube.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"1.0.0",
+       "cniVersion":"0.4.0",
        "name":"kilo",
        "plugins":[
           {

--- a/manifests/kilo-k3s-userspace-heterogeneous.yaml
+++ b/manifests/kilo-k3s-userspace-heterogeneous.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"1.0.0",
+       "cniVersion":"0.4.0",
        "name":"kilo",
        "plugins":[
           {

--- a/manifests/kilo-k3s-userspace.yaml
+++ b/manifests/kilo-k3s-userspace.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"1.0.0",
+       "cniVersion":"0.4.0",
        "name":"kilo",
        "plugins":[
           {

--- a/manifests/kilo-k3s.yaml
+++ b/manifests/kilo-k3s.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"1.0.0",
+       "cniVersion":"0.4.0",
        "name":"kilo",
        "plugins":[
           {

--- a/manifests/kilo-kubeadm-userspace.yaml
+++ b/manifests/kilo-kubeadm-userspace.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"1.0.0",
+       "cniVersion":"0.4.0",
        "name":"kilo",
        "plugins":[
           {

--- a/manifests/kilo-kubeadm.yaml
+++ b/manifests/kilo-kubeadm.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"1.0.0",
+       "cniVersion":"0.4.0",
        "name":"kilo",
        "plugins":[
           {

--- a/manifests/kilo-typhoon.yaml
+++ b/manifests/kilo-typhoon.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"1.0.0",
+       "cniVersion":"0.4.0",
        "name":"kilo",
        "plugins":[
           {


### PR DESCRIPTION
As mentioned in the Kilo Slack [0], Kubernetes supports CNI 0.4.0 and
does not yet support 1.0.0. Correspondingly, this commit downgrades the
declared CNI version in the configuration to 0.4.0 and crucially updates
the configuration used in the e2e tests to exercise this new CNI
version.

[0] https://kubernetes.slack.com/archives/C022EB4R7TK/p1650455432970199?thread_ts=1650368553.132859&cid=C022EB4R7TK

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
