### PR TITLE
Make dropping of other IPIP traffic optional

### DIFF
--- a/cmd/kg/main.go
+++ b/cmd/kg/main.go
@@ -146,7 +146,7 @@ func init() {
 	cmd.Flags().DurationVar(&resyncPeriod, "resync-period", 30*time.Second, "How often should the Kilo controllers reconcile?")
 	cmd.Flags().BoolVar(&iptablesForwardRule, "iptables-forward-rules", false, "Add default accept rules to the FORWARD chain in iptables. Warning: this may break firewalls with a deny all policy and is potentially insecure!")
 	cmd.Flags().BoolVar(&prioritisePrivateAddr, "prioritise-private-addresses", false, "Prefer to assign a private IP address to the node's endpoint.")
-	cmd.Flags().BoolVar(&dropOtherIpIpTraffic, "drop-other-ipip-traffic", true, "Drop other IP-over-IP traffic (not available in compatibility mode).")
+	cmd.Flags().BoolVar(&dropOtherIpIpTraffic, "drop-other-ipip-traffic", true, "Should Kilo drop other IP-over-IP traffic (not available in compatibility mode)?")
 
 	cmd.PersistentFlags().BoolVar(&printVersion, "version", false, "Print version and exit")
 	cmd.PersistentFlags().StringVar(&logLevel, "log-level", logLevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", availableLogLevels))

--- a/cmd/kg/main.go
+++ b/cmd/kg/main.go
@@ -115,6 +115,7 @@ var (
 	resyncPeriod          time.Duration
 	iptablesForwardRule   bool
 	prioritisePrivateAddr bool
+	dropOtherIpIpTraffic  bool
 
 	printVersion bool
 	logLevel     string
@@ -145,6 +146,7 @@ func init() {
 	cmd.Flags().DurationVar(&resyncPeriod, "resync-period", 30*time.Second, "How often should the Kilo controllers reconcile?")
 	cmd.Flags().BoolVar(&iptablesForwardRule, "iptables-forward-rules", false, "Add default accept rules to the FORWARD chain in iptables. Warning: this may break firewalls with a deny all policy and is potentially insecure!")
 	cmd.Flags().BoolVar(&prioritisePrivateAddr, "prioritise-private-addresses", false, "Prefer to assign a private IP address to the node's endpoint.")
+	cmd.Flags().BoolVar(&dropOtherIpIpTraffic, "drop-other-ipip-traffic", true, "Drop other IP-over-IP traffic (not available in compatibility mode).")
 
 	cmd.PersistentFlags().BoolVar(&printVersion, "version", false, "Print version and exit")
 	cmd.PersistentFlags().StringVar(&logLevel, "log-level", logLevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", availableLogLevels))
@@ -216,7 +218,7 @@ func runRoot(_ *cobra.Command, _ []string) error {
 	case "cilium":
 		enc = encapsulation.NewCilium(e)
 	default:
-		enc = encapsulation.NewIPIP(e)
+		enc = encapsulation.NewIPIP(e, dropOtherIpIpTraffic)
 	}
 
 	gr := mesh.Granularity(granularity)

--- a/docs/kg.md
+++ b/docs/kg.md
@@ -38,6 +38,7 @@ Flags:
       --cni-path string                Path to CNI config. (default "/etc/cni/net.d/10-kilo.conflist")
       --compatibility string           Should Kilo run in compatibility mode? Possible values: flannel
       --create-interface               Should kilo create an interface on startup? (default true)
+      --drop-other-ipip-traffic        Should Kilo drop other IP-over-IP traffic (not available in compatibility mode)? (default true)
       --encapsulate string             When should Kilo encapsulate packets within a location? Possible values: never, crosssubnet, always (default "always")
   -h, --help                           help for kg
       --hostname string                Hostname of the node on which this process is running.

--- a/pkg/mesh/routes_test.go
+++ b/pkg/mesh/routes_test.go
@@ -1086,7 +1086,7 @@ func TestRoutes(t *testing.T) {
 			},
 		},
 	} {
-		routes, rules := tc.topology.Routes(DefaultKiloInterface, kiloIface, privIface, tunlIface, tc.local, encapsulation.NewIPIP(tc.strategy))
+		routes, rules := tc.topology.Routes(DefaultKiloInterface, kiloIface, privIface, tunlIface, tc.local, encapsulation.NewIPIP(tc.strategy, true))
 		if diff := pretty.Compare(routes, tc.routes); diff != "" {
 			t.Errorf("test case %q: got diff: %v", tc.name, diff)
 		}


### PR DESCRIPTION
We faced some issues with misconfigured iptables when kilo is used in conjunction with kube-router. While this PR does not fix the underlying issue, it does optionally allow enabling a workaround that prevents the misconfiguration.