### PR TITLE
e2e/kilo-kind-userspace.yaml: fix boringtun cli flags

### DIFF
--- a/e2e/kilo-kind-userspace.yaml
+++ b/e2e/kilo-kind-userspace.yaml
@@ -136,9 +136,9 @@ spec:
           mountPath: /etc/kubernetes
           readOnly: true
       - name: boringtun
-        image: leonnicolas/boringtun:cc19859
+        image: leonnicolas/boringtun
         args:
-        - --disable-drop-privileges=true
+        - --disable-drop-privileges
         - --foreground
         - kilo0
         securityContext:

--- a/e2e/lib.sh
+++ b/e2e/lib.sh
@@ -65,7 +65,7 @@ build_kind_config() {
 }
 
 create_interface() {
-	docker run -d --name="$1" --rm --network=host --cap-add=NET_ADMIN --device=/dev/net/tun -v /var/run/wireguard:/var/run/wireguard -e WG_LOG_LEVEL=debug leonnicolas/boringtun:cc19859 --foreground --disable-drop-privileges true "$1"
+	docker run -d --name="$1" --rm --network=host --cap-add=NET_ADMIN --device=/dev/net/tun -v /var/run/wireguard:/var/run/wireguard -e WG_LOG_LEVEL=debug leonnicolas/boringtun --foreground --disable-drop-privileges "$1"
 }
 
 delete_interface() {

--- a/manifests/kilo-k3s-userspace-heterogeneous.yaml
+++ b/manifests/kilo-k3s-userspace-heterogeneous.yaml
@@ -300,7 +300,7 @@ spec:
       - name: boringtun
         image: leonnicolas/boringtun:cc19859
         args:
-        - --disable-drop-privileges=true
+        - --disable-drop-privileges
         - --foreground
         - kilo0
         securityContext:

--- a/manifests/kilo-k3s-userspace.yaml
+++ b/manifests/kilo-k3s-userspace.yaml
@@ -167,7 +167,7 @@ spec:
       - name: boringtun
         image: leonnicolas/boringtun:cc19859
         args:
-        - --disable-drop-privileges=true
+        - --disable-drop-privileges
         - --foreground
         - kilo0
         securityContext:

--- a/manifests/kilo-kubeadm-userspace.yaml
+++ b/manifests/kilo-kubeadm-userspace.yaml
@@ -104,7 +104,7 @@ spec:
         image: leonnicolas/boringtun:cc19859
         imagePullPolicy: IfNotPresent
         args:
-          - --disable-drop-privileges=true
+          - --disable-drop-privileges
           - --foreground
           - kilo0
         securityContext:


### PR DESCRIPTION
A change in boringtun's cli caused the boringtun container to crash.

Signed-off-by: leonnicolas <leonloechner@gmx.de>
