### PR TITLE
.github/workflows/ci.yml: run e2e daily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,6 @@ jobs:
       run: make unit
 
   e2e:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The e2e tests are not flaky anymore, so we should run them daily to see
if they break for whatever reason. This way we notice before someone
makes a "goog" PR.

Signed-off-by: leonnicolas <leonloechner@gmx.de>
