### PR TITLE
Add metrics for iptables operations

### DIFF
--- a/cmd/kg/main.go
+++ b/cmd/kg/main.go
@@ -245,7 +245,7 @@ func runRoot(_ *cobra.Command, _ []string) error {
 	if port < 1 || port > 1<<16-1 {
 		return fmt.Errorf("invalid port: port mus be in range [%d:%d], but got %d", 1, 1<<16-1, port)
 	}
-	m, err := mesh.New(b, enc, gr, hostname, port, s, local, cni, cniPath, iface, cleanUpIface, createIface, mtu, resyncPeriod, prioritisePrivateAddr, iptablesForwardRule, log.With(logger, "component", "kilo"))
+	m, err := mesh.New(b, enc, gr, hostname, port, s, local, cni, cniPath, iface, cleanUpIface, createIface, mtu, resyncPeriod, prioritisePrivateAddr, iptablesForwardRule, log.With(logger, "component", "kilo"), registry)
 	if err != nil {
 		return fmt.Errorf("failed to create Kilo mesh: %v", err)
 	}

--- a/cmd/kg/main.go
+++ b/cmd/kg/main.go
@@ -250,8 +250,6 @@ func runRoot(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to create Kilo mesh: %v", err)
 	}
 
-	m.RegisterMetrics(registry)
-
 	var g run.Group
 	{
 		h := internalserver.NewHandler(

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -16,7 +16,6 @@ package iptables
 
 import (
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
 	"io"
 	"net"
 	"os"
@@ -26,6 +25,7 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const ipv6ModuleDisabledPath = "/sys/module/ipv6/parameters/disable"

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -275,11 +275,7 @@ func New(opts ...ControllerOption) (*Controller, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create iptables IPv4 client: %v", err)
 		}
-		if c.registerer != nil {
-			c.v4 = wrapWithMetrics(v4, "IPv4", c.registerer)
-		} else {
-			c.v4 = v4
-		}
+		c.v4 = wrapWithMetrics(v4, "IPv4", c.registerer)
 	}
 	if c.v6 == nil {
 		disabled, err := ipv6Disabled()
@@ -294,11 +290,7 @@ func New(opts ...ControllerOption) (*Controller, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to create iptables IPv6 client: %v", err)
 			}
-			if c.registerer != nil {
-				c.v6 = wrapWithMetrics(v6, "IPv6", c.registerer)
-			} else {
-				c.v6 = v6
-			}
+			c.v6 = wrapWithMetrics(v6, "IPv6", c.registerer)
 		}
 	}
 	return c, nil

--- a/pkg/iptables/iptables_test.go
+++ b/pkg/iptables/iptables_test.go
@@ -15,6 +15,7 @@
 package iptables
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
 	"testing"
 )
 
@@ -84,7 +85,7 @@ func TestSet(t *testing.T) {
 		},
 	} {
 		client := &fakeClient{}
-		controller, err := New(WithClients(client, client))
+		controller, err := New(prometheus.NewRegistry(), WithClients(client, client))
 		if err != nil {
 			t.Fatalf("test case %q: got unexpected error instantiating controller: %v", tc.name, err)
 		}
@@ -141,7 +142,7 @@ func TestCleanUp(t *testing.T) {
 		},
 	} {
 		client := &fakeClient{}
-		controller, err := New(WithClients(client, client))
+		controller, err := New(prometheus.NewRegistry(), WithClients(client, client))
 		if err != nil {
 			t.Fatalf("test case %q: got unexpected error instantiating controller: %v", tc.name, err)
 		}

--- a/pkg/iptables/iptables_test.go
+++ b/pkg/iptables/iptables_test.go
@@ -15,7 +15,6 @@
 package iptables
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
 	"testing"
 )
 
@@ -85,7 +84,7 @@ func TestSet(t *testing.T) {
 		},
 	} {
 		client := &fakeClient{}
-		controller, err := New(prometheus.NewRegistry(), WithClients(client, client))
+		controller, err := New(WithClients(client, client))
 		if err != nil {
 			t.Fatalf("test case %q: got unexpected error instantiating controller: %v", tc.name, err)
 		}
@@ -142,7 +141,7 @@ func TestCleanUp(t *testing.T) {
 		},
 	} {
 		client := &fakeClient{}
-		controller, err := New(prometheus.NewRegistry(), WithClients(client, client))
+		controller, err := New(WithClients(client, client))
 		if err != nil {
 			t.Fatalf("test case %q: got unexpected error instantiating controller: %v", tc.name, err)
 		}

--- a/pkg/iptables/metrics.go
+++ b/pkg/iptables/metrics.go
@@ -24,6 +24,10 @@ type metricsClientWrapper struct {
 }
 
 func wrapWithMetrics(client Client, protocol string, registerer prometheus.Registerer) Client {
+	if registerer == nil {
+		return client
+	}
+
 	labelNames := []string{
 		"operation",
 		"table",

--- a/pkg/iptables/metrics.go
+++ b/pkg/iptables/metrics.go
@@ -1,0 +1,111 @@
+// Copyright 2019 the Kilo authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iptables
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type metricsClientWrapper struct {
+	client           Client
+	operationCounter *prometheus.CounterVec
+}
+
+func wrapWithMetrics(client Client, protocol string, registerer prometheus.Registerer) Client {
+	labelNames := []string{
+		"operation",
+		"table",
+		"chain",
+	}
+	counter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name:        "kilo_iptables_operations_total",
+		Help:        "Number of iptables operations.",
+		ConstLabels: prometheus.Labels{"protocol": protocol},
+	}, labelNames)
+	registerer.MustRegister(counter)
+	return &metricsClientWrapper{client, counter}
+}
+
+func (m *metricsClientWrapper) AppendUnique(table string, chain string, rule ...string) error {
+	m.operationCounter.With(prometheus.Labels{
+		"operation": "AppendUnique",
+		"table":     table,
+		"chain":     chain,
+	}).Inc()
+	return m.client.AppendUnique(table, chain, rule...)
+}
+
+func (m *metricsClientWrapper) Delete(table string, chain string, rule ...string) error {
+	m.operationCounter.With(prometheus.Labels{
+		"operation": "Delete",
+		"table":     table,
+		"chain":     chain,
+	}).Inc()
+	return m.client.Delete(table, chain, rule...)
+}
+
+func (m *metricsClientWrapper) Exists(table string, chain string, rule ...string) (bool, error) {
+	m.operationCounter.With(prometheus.Labels{
+		"operation": "Exists",
+		"table":     table,
+		"chain":     chain,
+	}).Inc()
+	return m.client.Exists(table, chain, rule...)
+}
+
+func (m *metricsClientWrapper) List(table string, chain string) ([]string, error) {
+	m.operationCounter.With(prometheus.Labels{
+		"operation": "List",
+		"table":     table,
+		"chain":     chain,
+	}).Inc()
+	return m.client.List(table, chain)
+}
+
+func (m *metricsClientWrapper) ClearChain(table string, chain string) error {
+	m.operationCounter.With(prometheus.Labels{
+		"operation": "ClearChain",
+		"table":     table,
+		"chain":     chain,
+	}).Inc()
+	return m.client.ClearChain(table, chain)
+}
+
+func (m *metricsClientWrapper) DeleteChain(table string, chain string) error {
+	m.operationCounter.With(prometheus.Labels{
+		"operation": "DeleteChain",
+		"table":     table,
+		"chain":     chain,
+	}).Inc()
+	return m.client.DeleteChain(table, chain)
+}
+
+func (m *metricsClientWrapper) NewChain(table string, chain string) error {
+	m.operationCounter.With(prometheus.Labels{
+		"operation": "NewChain",
+		"table":     table,
+		"chain":     chain,
+	}).Inc()
+	return m.client.NewChain(table, chain)
+}
+
+func (m *metricsClientWrapper) ListChains(table string) ([]string, error) {
+	m.operationCounter.With(prometheus.Labels{
+		"operation": "ListChains",
+		"table":     table,
+		"chain":     "",
+	}).Inc()
+	return m.client.ListChains(table)
+}

--- a/pkg/iptables/metrics.go
+++ b/pkg/iptables/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2019 the Kilo authors
+// Copyright 2022 the Kilo authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/iptables/metrics.go
+++ b/pkg/iptables/metrics.go
@@ -105,7 +105,7 @@ func (m *metricsClientWrapper) ListChains(table string) ([]string, error) {
 	m.operationCounter.With(prometheus.Labels{
 		"operation": "ListChains",
 		"table":     table,
-		"chain":     "",
+		"chain":     "*",
 	}).Inc()
 	return m.client.ListChains(table)
 }

--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -156,7 +156,7 @@ func New(backend Backend, enc encapsulation.Encapsulator, granularity Granularit
 		externalIP = publicIP
 	}
 	level.Debug(logger).Log("msg", fmt.Sprintf("using %s as the public IP address", publicIP.String()))
-	ipTables, err := iptables.New(registerer, iptables.WithLogger(log.With(logger, "component", "iptables")), iptables.WithResyncPeriod(resyncPeriod))
+	ipTables, err := iptables.New(iptables.WithRegisterer(registerer), iptables.WithLogger(log.With(logger, "component", "iptables")), iptables.WithResyncPeriod(resyncPeriod))
 	if err != nil {
 		return nil, fmt.Errorf("failed to IP tables controller: %v", err)
 	}

--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -88,7 +88,7 @@ type Mesh struct {
 }
 
 // New returns a new Mesh instance.
-func New(backend Backend, enc encapsulation.Encapsulator, granularity Granularity, hostname string, port int, subnet *net.IPNet, local, cni bool, cniPath, iface string, cleanUpIface bool, createIface bool, mtu uint, resyncPeriod time.Duration, prioritisePrivateAddr, iptablesForwardRule bool, logger log.Logger) (*Mesh, error) {
+func New(backend Backend, enc encapsulation.Encapsulator, granularity Granularity, hostname string, port int, subnet *net.IPNet, local, cni bool, cniPath, iface string, cleanUpIface bool, createIface bool, mtu uint, resyncPeriod time.Duration, prioritisePrivateAddr, iptablesForwardRule bool, logger log.Logger, registerer prometheus.Registerer) (*Mesh, error) {
 	if err := os.MkdirAll(kiloPath, 0700); err != nil {
 		return nil, fmt.Errorf("failed to create directory to store configuration: %v", err)
 	}
@@ -156,7 +156,7 @@ func New(backend Backend, enc encapsulation.Encapsulator, granularity Granularit
 		externalIP = publicIP
 	}
 	level.Debug(logger).Log("msg", fmt.Sprintf("using %s as the public IP address", publicIP.String()))
-	ipTables, err := iptables.New(iptables.WithLogger(log.With(logger, "component", "iptables")), iptables.WithResyncPeriod(resyncPeriod))
+	ipTables, err := iptables.New(registerer, iptables.WithLogger(log.With(logger, "component", "iptables")), iptables.WithResyncPeriod(resyncPeriod))
 	if err != nil {
 		return nil, fmt.Errorf("failed to IP tables controller: %v", err)
 	}


### PR DESCRIPTION
To have better visibility of the iptables operations performed by kilo it would be nice to have prom metrics for them.

This PR introduces such metrics for all iptables operations by wrapping a proxy around the iptables client.