### PR TITLE
Make cleanup on shutdown optional

### DIFF
--- a/cmd/kg/main.go
+++ b/cmd/kg/main.go
@@ -127,8 +127,8 @@ var (
 
 func init() {
 	cmd.Flags().StringVar(&backend, "backend", k8s.Backend, fmt.Sprintf("The backend for the mesh. Possible values: %s", availableBackends))
-	cmd.Flags().BoolVar(&cleanUp, "clean-up", true, "Clean up network modifications on shutdown.")
-	cmd.Flags().BoolVar(&cleanUpIface, "clean-up-interface", false, "Should Kilo delete its interface when it shuts down? Only relevant when cleanup is true.")
+	cmd.Flags().BoolVar(&cleanUp, "clean-up", true, "Should kilo clean up network modifications on shutdown?")
+	cmd.Flags().BoolVar(&cleanUpIface, "clean-up-interface", false, "Should Kilo delete its interface when it shuts down?")
 	cmd.Flags().BoolVar(&createIface, "create-interface", true, "Should kilo create an interface on startup?")
 	cmd.Flags().BoolVar(&cni, "cni", true, "Should Kilo manage the node's CNI configuration?")
 	cmd.Flags().StringVar(&cniPath, "cni-path", mesh.DefaultCNIPath, "Path to CNI config.")

--- a/cmd/kg/main.go
+++ b/cmd/kg/main.go
@@ -95,6 +95,7 @@ var cmd = &cobra.Command{
 
 var (
 	backend               string
+	cleanUp               bool
 	cleanUpIface          bool
 	createIface           bool
 	cni                   bool
@@ -126,7 +127,8 @@ var (
 
 func init() {
 	cmd.Flags().StringVar(&backend, "backend", k8s.Backend, fmt.Sprintf("The backend for the mesh. Possible values: %s", availableBackends))
-	cmd.Flags().BoolVar(&cleanUpIface, "clean-up-interface", false, "Should Kilo delete its interface when it shuts down?")
+	cmd.Flags().BoolVar(&cleanUp, "clean-up", false, "Clean up network modifications on shutdown.")
+	cmd.Flags().BoolVar(&cleanUpIface, "clean-up-interface", false, "Should Kilo delete its interface when it shuts down? Only relevant when cleanup is true.")
 	cmd.Flags().BoolVar(&createIface, "create-interface", true, "Should kilo create an interface on startup?")
 	cmd.Flags().BoolVar(&cni, "cni", true, "Should Kilo manage the node's CNI configuration?")
 	cmd.Flags().StringVar(&cniPath, "cni-path", mesh.DefaultCNIPath, "Path to CNI config.")
@@ -257,7 +259,7 @@ func runRoot(_ *cobra.Command, _ []string) error {
 		serviceCIDRs = append(serviceCIDRs, s)
 	}
 
-	m, err := mesh.New(b, enc, gr, hostname, port, s, local, cni, cniPath, iface, cleanUpIface, createIface, mtu, resyncPeriod, prioritisePrivateAddr, iptablesForwardRule, serviceCIDRs, log.With(logger, "component", "kilo"), registry)
+	m, err := mesh.New(b, enc, gr, hostname, port, s, local, cni, cniPath, iface, cleanUp, cleanUpIface, createIface, mtu, resyncPeriod, prioritisePrivateAddr, iptablesForwardRule, serviceCIDRs, log.With(logger, "component", "kilo"), registry)
 	if err != nil {
 		return fmt.Errorf("failed to create Kilo mesh: %v", err)
 	}

--- a/cmd/kg/main.go
+++ b/cmd/kg/main.go
@@ -127,7 +127,7 @@ var (
 
 func init() {
 	cmd.Flags().StringVar(&backend, "backend", k8s.Backend, fmt.Sprintf("The backend for the mesh. Possible values: %s", availableBackends))
-	cmd.Flags().BoolVar(&cleanUp, "clean-up", false, "Clean up network modifications on shutdown.")
+	cmd.Flags().BoolVar(&cleanUp, "clean-up", true, "Clean up network modifications on shutdown.")
 	cmd.Flags().BoolVar(&cleanUpIface, "clean-up-interface", false, "Should Kilo delete its interface when it shuts down? Only relevant when cleanup is true.")
 	cmd.Flags().BoolVar(&createIface, "create-interface", true, "Should kilo create an interface on startup?")
 	cmd.Flags().BoolVar(&cni, "cni", true, "Should Kilo manage the node's CNI configuration?")

--- a/docs/kg.md
+++ b/docs/kg.md
@@ -33,6 +33,7 @@ Available Commands:
 
 Flags:
       --backend string                 The backend for the mesh. Possible values: kubernetes (default "kubernetes")
+      --clean-up                       Should kilo clean up network modifications on shutdown? (default true)
       --clean-up-interface             Should Kilo delete its interface when it shuts down?
       --cni                            Should Kilo manage the node's CNI configuration? (default true)
       --cni-path string                Path to CNI config. (default "/etc/cni/net.d/10-kilo.conflist")


### PR DESCRIPTION
We've been looking into making kilo rollouts not resulting in a network-related downtime that's the result of cleanup on shutdown. From what I can tell almost all operations are already idempotent _anyway_.

The only issue i've been able to identify is the creation of the wireguard interface on startup - making that code path check for existence before trying to create a new one should prevent any issues there.

So far it's just an experiment, but I'd love to hear your thoughts on it!