### PR TITLE
Don't always write private key to disk

### DIFF
--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -102,13 +102,13 @@ func New(backend Backend, enc encapsulation.Encapsulator, granularity Granularit
 		if private, err = wgtypes.GeneratePrivateKey(); err != nil {
 			return nil, err
 		}
+		if err := os.WriteFile(privateKeyPath, []byte(private.String()), 0600); err != nil {
+			return nil, fmt.Errorf("failed to write private key to disk: %v", err)
+		}
 	}
 	public := private.PublicKey()
 	if err != nil {
 		return nil, err
-	}
-	if err := os.WriteFile(privateKeyPath, []byte(private.String()), 0600); err != nil {
-		return nil, fmt.Errorf("failed to write private key to disk: %v", err)
 	}
 	cniIndex, err := cniDeviceIndex()
 	if err != nil {


### PR DESCRIPTION
Only write private key to disk on new key generation. Otherwise just use what is there. This allows externally key generation and injection with a secret.