### PR TITLE
CI: stop enabling experimental docker features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,15 +146,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: 1.19
-    - name: Enable Experimental Docker CLI
-      run: |
-        echo $'{\n  "experimental": true\n}' | sudo tee /etc/docker/daemon.json
-        mkdir -p ~/.docker
-        echo $'{\n  "experimental": "enabled"\n}' | sudo tee ~/.docker/config.json
-        sudo service docker restart
-        docker version -f '{{.Client.Experimental}}'
-        docker version -f '{{.Server.Experimental}}'
-        docker buildx version
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
       with:


### PR DESCRIPTION
This is probably not experimental anymore.
Hopefully now CI will be green.

Signed-off-by: leonnicolas <leonloechner@gmx.de>
