### PR TITLE
Compatibility calico bgp #377

### DIFF
--- a/cmd/kg/handlers.go
+++ b/cmd/kg/handlers.go
@@ -65,7 +65,7 @@ func (h *graphHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			peers[p.Name] = p
 		}
 	}
-	topo, err := mesh.NewTopology(nodes, peers, h.granularity, *h.hostname, 0, wgtypes.Key{}, h.subnet, h.serviceCIDRs, nodes[*h.hostname].PersistentKeepalive, nil)
+	topo, err := mesh.NewTopology(nodes, peers, nil, h.granularity, *h.hostname, 0, wgtypes.Key{}, h.subnet, h.serviceCIDRs, nodes[*h.hostname].PersistentKeepalive, nil)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to create topology: %v", err), http.StatusInternalServerError)
 		return

--- a/cmd/kgctl/graph.go
+++ b/cmd/kgctl/graph.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/squat/kilo/pkg/mesh"
 )
@@ -67,7 +68,8 @@ func runGraph(_ *cobra.Command, _ []string) error {
 			peers[p.Name] = p
 		}
 	}
-	t, err := mesh.NewTopology(nodes, peers, opts.granularity, hostname, 0, wgtypes.Key{}, subnet, nil, nodes[hostname].PersistentKeepalive, nil)
+	pods := make(map[types.UID]*mesh.Pod)
+	t, err := mesh.NewTopology(nodes, peers, pods, opts.granularity, hostname, 0, wgtypes.Key{}, subnet, nil, nodes[hostname].PersistentKeepalive, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create topology: %w", err)
 	}

--- a/cmd/kgctl/main.go
+++ b/cmd/kgctl/main.go
@@ -94,7 +94,7 @@ func runRoot(c *cobra.Command, _ []string) error {
 		c := kubernetes.NewForConfigOrDie(config)
 		opts.kc = kiloclient.NewForConfigOrDie(config)
 		ec := apiextensions.NewForConfigOrDie(config)
-		opts.backend = k8s.New(c, opts.kc, ec, topologyLabel, log.NewNopLogger())
+		opts.backend = k8s.New(c, opts.kc, ec, topologyLabel, log.NewNopLogger(), false)
 	default:
 		return fmt.Errorf("backend %s unknown; posible values are: %s", backend, availableBackends)
 	}

--- a/cmd/kgctl/showconf.go
+++ b/cmd/kgctl/showconf.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/squat/kilo/pkg/k8s/apis/kilo/v1alpha1"
 	"github.com/squat/kilo/pkg/mesh"
@@ -152,7 +153,9 @@ func runShowConfNode(_ *cobra.Command, args []string) error {
 		}
 	}
 
-	t, err := mesh.NewTopology(nodes, peers, opts.granularity, hostname, int(opts.port), wgtypes.Key{}, subnet, nil, nodes[hostname].PersistentKeepalive, nil)
+	pods := make(map[types.UID]*mesh.Pod)
+
+	t, err := mesh.NewTopology(nodes, peers, pods, opts.granularity, hostname, int(opts.port), wgtypes.Key{}, subnet, nil, nodes[hostname].PersistentKeepalive, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create topology: %w", err)
 	}
@@ -251,11 +254,13 @@ func runShowConfPeer(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("did not find any peer named %q in the cluster", peer)
 	}
 
+	pods := make(map[types.UID]*mesh.Pod)
+
 	pka := time.Duration(0)
 	if p := peers[peer].PersistentKeepaliveInterval; p != nil {
 		pka = *p
 	}
-	t, err := mesh.NewTopology(nodes, peers, opts.granularity, hostname, mesh.DefaultKiloPort, wgtypes.Key{}, subnet, nil, pka, nil)
+	t, err := mesh.NewTopology(nodes, peers, pods, opts.granularity, hostname, mesh.DefaultKiloPort, wgtypes.Key{}, subnet, nil, pka, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create topology: %w", err)
 	}

--- a/manifests/kilo-k3s-calico-bgp.yaml
+++ b/manifests/kilo-k3s-calico-bgp.yaml
@@ -1,0 +1,176 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kilo
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kilo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - kilo.squat.ai
+  resources:
+  - peers
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kilo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kilo
+subjects:
+  - kind: ServiceAccount
+    name: kilo
+    namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kilo-scripts
+  namespace: kube-system
+data:
+  init.sh: |
+    #!/bin/sh
+    cat > /etc/kubernetes/kubeconfig <<EOF
+        apiVersion: v1
+        kind: Config
+        name: kilo
+        clusters:
+        - cluster:
+            server: $(sed -n 's/.*server: \(.*\)/\1/p' /var/lib/rancher/k3s/agent/kubelet.kubeconfig)
+            certificate-authority: /var/lib/rancher/k3s/agent/server-ca.crt
+        users:
+        - name: kilo
+          user:
+            token: $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+        contexts:
+        - name: kilo
+          context:
+            cluster: kilo
+            namespace: ${NAMESPACE}
+            user: kilo
+        current-context: kilo
+    EOF
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kilo
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: kilo
+    app.kubernetes.io/part-of: kilo
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kilo
+      app.kubernetes.io/part-of: kilo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kilo
+        app.kubernetes.io/part-of: kilo
+    spec:
+      serviceAccountName: kilo
+      hostNetwork: true
+      containers:
+      - name: kilo
+        image: squat/kilo:latest
+        imagePullPolicy: Always
+        args:
+        - --kubeconfig=/etc/kubernetes/kubeconfig
+        - --hostname=$(NODE_NAME)
+        - --cni=false
+        - --compatibility=calico-bgp
+        - --local=false
+        - --encapsulate=crosssubnet
+        - --clean-up-interface=true
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        ports:
+        - containerPort: 1107
+          name: metrics
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: kilo-dir
+          mountPath: /var/lib/kilo
+        - name: kubeconfig
+          mountPath: /etc/kubernetes
+        - name: lib-modules
+          mountPath: /lib/modules
+          readOnly: true
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
+          readOnly: false
+      initContainers:
+      - name: generate-kubeconfig
+        image: squat/kilo:0.6.0
+        command:
+        - /bin/sh
+        args:
+        - /scripts/init.sh
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: kubeconfig
+          mountPath: /etc/kubernetes
+        - name: scripts
+          mountPath: /scripts/
+          readOnly: true
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      volumes:
+      - name: kilo-dir
+        hostPath:
+          path: /var/lib/kilo4
+      - name: kubeconfig
+        emptyDir: {}
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+      - name: scripts
+        configMap:
+          name: kilo-scripts

--- a/pkg/mesh/backend.go
+++ b/pkg/mesh/backend.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/squat/kilo/pkg/wireguard"
 )
@@ -106,6 +107,18 @@ func (p *Peer) Ready() bool {
 		p.PublicKey != wgtypes.Key{} // If Key was not set, it will be wgtypes.Key{}.
 }
 
+type Pod struct {
+	Uid       types.UID
+	Name      string
+	Namespace string
+	NodeName  string
+	IP        *net.IPNet
+}
+
+func (p *Pod) Ready() bool {
+	return p != nil
+}
+
 // EventType describes what kind of an action an event represents.
 type EventType string
 
@@ -132,6 +145,12 @@ type PeerEvent struct {
 	Old  *Peer
 }
 
+type PodEvent struct {
+	Type EventType
+	Pod  *Pod
+	Old  *Pod
+}
+
 // Backend can create clients for all of the
 // primitive types that Kilo deals with, namely:
 // * nodes; and
@@ -139,6 +158,7 @@ type PeerEvent struct {
 type Backend interface {
 	Nodes() NodeBackend
 	Peers() PeerBackend
+	Pods() PodBackend
 }
 
 // NodeBackend can get nodes by name, init itself,
@@ -167,4 +187,10 @@ type PeerBackend interface {
 	List() ([]*Peer, error)
 	Set(context.Context, string, *Peer) error
 	Watch() <-chan *PeerEvent
+}
+
+type PodBackend interface {
+	Init(context.Context) error
+	List() ([]*Pod, error)
+	Watch() <-chan *PodEvent
 }

--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -759,7 +759,7 @@ func peersAreEqual(a, b *Peer) bool {
 }
 
 func podsAreEqual(a, b *Pod) bool {
-	if !(a != nil) == (b != nil) {
+	if (a != nil) != (b != nil) {
 		return false
 	}
 	if a == b {

--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -765,7 +765,7 @@ func podsAreEqual(a, b *Pod) bool {
 	if a == b {
 		return true
 	}
-	return a.Name == b.Name
+	return a.Uid == b.Uid
 }
 
 func ipNetsEqual(a, b *net.IPNet) bool {

--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -385,7 +385,7 @@ func (m *Mesh) syncPods(e *PodEvent) {
 
 	switch e.Type {
 	case UpdateEvent:
-        if !podsAreEqual(m.pods[key], e.Pod) {
+		if !podsAreEqual(m.pods[key], e.Pod) {
 			// Pod have IP => add allowed
 			if e.Pod.IP != nil {
 				m.pods[key] = e.Pod
@@ -393,7 +393,7 @@ func (m *Mesh) syncPods(e *PodEvent) {
 			}
 		}
 	case DeleteEvent:
-	    // Remove allowed
+		// Remove allowed
 		delete(m.pods, key)
 		diff = true
 	}

--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -765,7 +765,8 @@ func podsAreEqual(a, b *Pod) bool {
 	if a == b {
 		return true
 	}
-	return a.Uid == b.Uid
+	return a.Uid == b.Uid &&
+		a.IP == b.IP
 }
 
 func ipNetsEqual(a, b *net.IPNet) bool {

--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -782,9 +782,6 @@ func podsAreEqual(a, b *Pod) bool {
 	if (a != nil) != (b != nil) {
 		return false
 	}
-	if a == b {
-		return true
-	}
 	return a.Uid == b.Uid &&
 		a.IP == b.IP
 }


### PR DESCRIPTION
Following https://github.com/squat/kilo/issues/377

Add `calico-bgp` compatibility.

If compatibility enabled : 
- [x] Added detection of pod IP updates to enrich the "AllowedIps" attribute of WireGuard using the Status.podIP ;
- [ ] Stopped using node CIDR addresses because calico's IPAM plugin doesn't respect the values given to Node.Spec.PodCIDR ;

## How to use ? 

```
kubectl apply -f https://raw.githubusercontent.com/squat/kilo/main/manifests/crds.yaml
kubectl apply -f https://raw.githubusercontent.com/squat/kilo/main/manifests/kilo-k3s-calico-bgp.yaml
```