### PR TITLE
Polish help message

### DIFF
--- a/cmd/kg/main.go
+++ b/cmd/kg/main.go
@@ -54,12 +54,19 @@ const (
 	logLevelNone  = "none"
 )
 
+// Compatibility modes.
+const (
+	compatFlannel = "flannel"
+	compatCilium  = "cilium"
+)
+
 var (
 	availableBackends = strings.Join([]string{
 		k8s.Backend,
 	}, ", ")
 	availableCompatibilities = strings.Join([]string{
-		"flannel",
+		compatFlannel,
+		compatCilium,
 	}, ", ")
 	availableEncapsulations = strings.Join([]string{
 		string(encapsulation.Never),
@@ -150,7 +157,7 @@ func init() {
 	cmd.Flags().BoolVar(&iptablesForwardRule, "iptables-forward-rules", false, "Add default accept rules to the FORWARD chain in iptables. Warning: this may break firewalls with a deny all policy and is potentially insecure!")
 	cmd.Flags().BoolVar(&prioritisePrivateAddr, "prioritise-private-addresses", false, "Prefer to assign a private IP address to the node's endpoint.")
 
-	cmd.PersistentFlags().BoolVar(&printVersion, "version", false, "Print version and exit")
+	cmd.PersistentFlags().BoolVar(&printVersion, "version", false, "Print version and exit.")
 	cmd.PersistentFlags().StringVar(&logLevel, "log-level", logLevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", availableLogLevels))
 }
 
@@ -215,9 +222,9 @@ func runRoot(_ *cobra.Command, _ []string) error {
 
 	var enc encapsulation.Encapsulator
 	switch compatibility {
-	case "flannel":
+	case compatFlannel:
 		enc = encapsulation.NewFlannel(e)
-	case "cilium":
+	case compatCilium:
 		enc = encapsulation.NewCilium(e)
 	default:
 		enc = encapsulation.NewIPIP(e)

--- a/docs/kg.md
+++ b/docs/kg.md
@@ -37,7 +37,7 @@ Flags:
       --clean-up-interface             Should Kilo delete its interface when it shuts down?
       --cni                            Should Kilo manage the node's CNI configuration? (default true)
       --cni-path string                Path to CNI config. (default "/etc/cni/net.d/10-kilo.conflist")
-      --compatibility string           Should Kilo run in compatibility mode? Possible values: flannel
+      --compatibility string           Should Kilo run in compatibility mode? Possible values: flannel, cilium
       --create-interface               Should kilo create an interface on startup? (default true)
       --encapsulate string             When should Kilo encapsulate packets within a location? Possible values: never, crosssubnet, always (default "always")
   -h, --help                           help for kg
@@ -57,6 +57,6 @@ Flags:
       --service-cidr strings           The service CIDR for the Kubernetes cluster. Can be provided optionally to avoid masquerading packets sent to service IPs. Can be specified multiple times.
       --subnet string                  CIDR from which to allocate addresses for WireGuard interfaces. (default "10.4.0.0/16")
       --topology-label string          Kubernetes node label used to group nodes into logical locations. (default "topology.kubernetes.io/region")
-      --version                        Print version and exit
+      --version                        Print version and exit.
 
 ```


### PR DESCRIPTION
Added "cilium" which was missing in the help message.

```diff
-       --compatibility string           Should Kilo run in compatibility mode? Possible values: flannel
+       --compatibility string           Should Kilo run in compatibility mode? Possible values: flannel, cilium
```
