### PR TITLE
container: add kgctl binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,5 @@ COPY --from=cni bridge host-local loopback portmap /opt/cni/bin/
 ADD https://raw.githubusercontent.com/kubernetes-sigs/iptables-wrappers/e139a115350974aac8a82ec4b815d2845f86997e/iptables-wrapper-installer.sh /
 RUN chmod 700 /iptables-wrapper-installer.sh && /iptables-wrapper-installer.sh --no-sanity-check
 COPY bin/linux/$GOARCH/kg /opt/bin/
+COPY bin/linux/$GOARCH/kgctl /opt/bin/
 ENTRYPOINT ["/opt/bin/kg"]

--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ website/build/index.html: website/docs/README.md docs/api.md
 	yarn --cwd website build
 
 container: .container-$(ARCH)-$(VERSION) container-name
-.container-$(ARCH)-$(VERSION): bin/linux/$(ARCH)/kg Dockerfile
+.container-$(ARCH)-$(VERSION): bin/linux/$(ARCH)/kg bin/linux/$(ARCH)/kgctl Dockerfile
 	@i=0; for a in $(ALL_ARCH); do [ "$$a" = $(ARCH) ] && break; i=$$((i+1)); done; \
 	ia=""; iv=""; \
 	j=0; for a in $(DOCKER_ARCH); do \


### PR DESCRIPTION
This makes it easy to run Kilo sidecars that connect a workload to a
mesh using `kgctl connect`.

Signed-off-by: squat <lserven@gmail.com>
