### PR TITLE
kgctl: make peer name argument optional

### DIFF
--- a/docs/kgctl.md
+++ b/docs/kgctl.md
@@ -68,12 +68,12 @@ When the command exits, all of the configuration, including newly registered Pee
 Example:
 
 ```shell
-PEER_NAME=laptop
 SERVICECIDR=10.43.0.0/16
-kgctl connect $PEER_NAME --allowed-ips $SERVICECIDR
+kgctl connect --allowed-ips $SERVICECIDR
 ```
 
 The local host is now connected to the cluster and all IPs from the cluster and any registered Peers are fully routable.
+By default, `kgctl` will use the local host's hostname as the Peer name in the mesh; this can be overridden by providing an additional argument for the preferred name.
 When combined with the `--clean-up false` flag, the configuration produced by the command is persistent and will remain in effect even after the process is stopped.
 
 With the service CIDR of the cluster routable from the local host, Kubernetes DNS names can now be resolved by the cluster DNS provider.

--- a/e2e/kgctl.sh
+++ b/e2e/kgctl.sh
@@ -14,4 +14,10 @@ test_connect() {
         docker run -d --name="$PEER" --rm --network=host --cap-add=NET_ADMIN -v "$KGCTL_BINARY":/kgctl -v "$PWD/$KUBECONFIG":/kubeconfig --entrypoint=/kgctl alpine --kubeconfig /kubeconfig connect "$PEER" --allowed-ip "$ALLOWED_IP"
 	assert "retry 10 5 '' check_ping --local" "should be able to ping Pods from host"
         docker stop "$PEER"
+
+	local PEER=test-hostname
+	local ALLOWED_IP=10.5.0.1/32
+        docker run -d --name="$PEER" --rm --network=host --cap-add=NET_ADMIN -v "$KGCTL_BINARY":/kgctl -v "$PWD/$KUBECONFIG":/kubeconfig --entrypoint=/kgctl alpine --kubeconfig /kubeconfig connect --allowed-ip "$ALLOWED_IP"
+	assert "retry 10 5 '' check_ping --local" "should be able to ping Pods from host using auto-discovered name"
+        docker stop "$PEER"
 }


### PR DESCRIPTION
This commit makes the peer name argument in the `kgctl connect` command
optional. Now, the computer's hostname will be used as the default peer
name when no argument is supplied. This is a good predictable feature
that makes it easier to integrate with containers and environments like
Kubernetes.

Signed-off-by: squat <lserven@gmail.com>
