### PR TITLE
Docker: update iptables packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ BASH_UNIT := $(shell pwd)/bin/bash_unit
 BASH_UNIT_FLAGS :=
 
 BUILD_IMAGE ?= golang:1.19.0
-BASE_IMAGE ?= alpine:3.15
+BASE_IMAGE ?= alpine:3.20
 
 build: $(BINS)
 


### PR DESCRIPTION
Bump the Alpine container base image to update the packages that are
installed at container build-time.

Fixes: https://github.com/squat/kilo/issues/388

Signed-off-by: squat <lserven@gmail.com>
