### PR TITLE
fix(topology): allow allowed-location-ips to contain node IPs

### DIFF
--- a/pkg/mesh/topology.go
+++ b/pkg/mesh/topology.go
@@ -263,11 +263,11 @@ CheckIPs:
 				}
 			}
 			// Check if allowed location IPs intersect with the allowed IPs.
-			// If the allowed location IP fully contains an allowed IP, that's fine -
-			// the more specific route will be used. Only warn if it's a partial overlap
-			// where the allowed IP contains the allowed location IP.
+			// If the allowed location IP strictly contains an allowed IP, that's
+			// fine - the more specific route will be used. Reject if the allowed
+			// IP contains or equals the allowed location IP.
 			for _, i := range s.allowedIPs {
-				if i.Contains(ip.IP) && !ip.Contains(i.IP) {
+				if i.Contains(ip.IP) {
 					_ = level.Warn(t.logger).Log("msg", "overlapping allowed location IPnet with allowed IPnets", "IP", ip.String(), "IP2", i.String(), "segment-location", s.location)
 					continue CheckIPs
 				}


### PR DESCRIPTION
## Summary

Allow `allowed-location-ips` CIDRs to fully contain node internal IPs without being rejected.

## Problem

Previously, if an `allowed-location-ips` CIDR contained a node's internal IP or allowed IP, it was rejected with a warning:

```
overlapping allowed location IPnet with allowed IPnets
```

For example, setting `allowed-location-ips=192.168.100.0/24` on a node with internal IP `192.168.100.11` would fail.

## Solution

This was overly restrictive since WireGuard uses longest prefix match for routing. Now, if an `allowed-location-ip` fully contains a node's IP (e.g., `192.168.100.0/24` contains `192.168.100.11/32`), the `allowed-location-ip` is accepted.

The more specific route to the node's IP will still work correctly due to longest prefix match.

## Test plan

- [x] Build passes
- [ ] Tested with `allowed-location-ips` containing node IP