### PR TITLE
fix: Use TARGETARCH for multi-platform builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 ARG FROM=alpine
 FROM $FROM AS cni
-ARG GOARCH=amd64
+# TARGETARCH is automatically set by Docker buildx for multi-platform builds
+ARG TARGETARCH
+ARG GOARCH=${TARGETARCH:-amd64}
 ARG CNI_PLUGINS_VERSION=v1.1.1
 RUN apk add --no-cache curl && \
     curl -Lo cni.tar.gz https://github.com/containernetworking/plugins/releases/download/$CNI_PLUGINS_VERSION/cni-plugins-linux-$GOARCH-$CNI_PLUGINS_VERSION.tgz && \


### PR DESCRIPTION
## Summary

Enable ARM64 and other architecture support by using Docker's automatic `TARGETARCH` variable instead of hardcoded `GOARCH=amd64`.

## Problem

The current Dockerfile hardcodes `ARG GOARCH=amd64`, which prevents building images for other architectures like `arm64` using `docker buildx build --platform linux/arm64`.

## Solution

- Use `TARGETARCH` which is automatically set by Docker buildx during multi-platform builds
- Fall back to `amd64` for backward compatibility with non-buildx builds

## Changes

```dockerfile
# Before
ARG GOARCH=amd64

# After
ARG TARGETARCH
ARG GOARCH=${TARGETARCH:-amd64}
```

## Testing

Build for multiple platforms:
```bash
docker buildx build --platform linux/amd64,linux/arm64 -t kilo:test .
```