### PR TITLE
feat: auto-detect WireGuard MTU from underlay interface

### DIFF
--- a/docs/kg.md
+++ b/docs/kg.md
@@ -51,7 +51,7 @@ Flags:
       --log-level string               Log level to use. Possible values: all, debug, info, warn, error, none (default "info")
       --master string                  The address of the Kubernetes API server (overrides any value in kubeconfig).
       --mesh-granularity string        The granularity of the network mesh to create. Possible values: location, full (default "location")
-      --mtu uint                       The MTU of the WireGuard interface created by Kilo. (default 1420)
+      --mtu string                     The MTU of the WireGuard interface created by Kilo. Set to 'auto' to detect from the underlay interface. (default "auto")
       --port int                       The port over which WireGuard peers should communicate. (default 51820)
       --prioritise-private-addresses   Prefer to assign a private IP address to the node's endpoint.
       --resync-period duration         How often should the Kilo controllers reconcile? (default 30s)

--- a/pkg/wireguard/wireguard.go
+++ b/pkg/wireguard/wireguard.go
@@ -26,6 +26,23 @@ import (
 // DefaultMTU is the the default MTU used by WireGuard.
 const DefaultMTU = 1420
 
+// WireGuardOverhead is the overhead in bytes added by WireGuard encapsulation.
+// IPv4 header (20) + UDP header (8) + WireGuard header (32) + MAC (16) + padding (4) = 80 bytes.
+const WireGuardOverhead = 80
+
+// SetMTU sets the MTU on the interface with the given index.
+// If the current MTU already matches, no change is made.
+func SetMTU(index int, mtu uint) error {
+	link, err := netlink.LinkByIndex(index)
+	if err != nil {
+		return fmt.Errorf("failed to get link: %v", err)
+	}
+	if link.Attrs().MTU == int(mtu) {
+		return nil
+	}
+	return netlink.LinkSetMTU(link, int(mtu))
+}
+
 type wgLink struct {
 	a netlink.LinkAttrs
 	t string


### PR DESCRIPTION
## Summary
- Change the `--mtu` flag default from a fixed `1420` to `"auto"`, which detects the MTU of the underlay network interface and subtracts the WireGuard overhead (80 bytes)
- Re-detect MTU on each reconciliation loop to handle interface changes
- The flag still accepts numeric values for manual override

## Motivation
In multi-cloud deployments, different locations may have different underlay MTUs (e.g. 1500 on bare metal vs 1400 on Azure). A fixed MTU causes packet fragmentation or drops when the underlay MTU is smaller than expected. Auto-detection eliminates the need for per-node MTU configuration.

## Changes
- `pkg/wireguard/wireguard.go`: Add `WireGuardOverhead` constant (80 bytes) and `SetMTU()` helper
- `pkg/mesh/mesh.go`: Add `detectMTU()` function, `mtu`/`autoMTU` fields, MTU re-detection in `applyTopology()`
- `cmd/kg/main.go`: Change `--mtu` flag from `uint` to `string` with `"auto"` default