### PR TITLE
mesh: set preferred source for WireGuard routes

### DIFF
--- a/pkg/mesh/routes_test.go
+++ b/pkg/mesh/routes_test.go
@@ -747,6 +747,7 @@ func TestRoutes(t *testing.T) {
 					Flags:     int(netlink.FLAG_ONLINK),
 					Gw:        nodes["c"].InternalIP.IP,
 					LinkIndex: tunlIface,
+					Src:       nodes["b"].InternalIP.IP,
 					Protocol:  unix.RTPROT_STATIC,
 				},
 				{
@@ -754,6 +755,7 @@ func TestRoutes(t *testing.T) {
 					Flags:     int(netlink.FLAG_ONLINK),
 					Gw:        nodes["c"].InternalIP.IP,
 					LinkIndex: tunlIface,
+					Src:       nodes["b"].InternalIP.IP,
 					Protocol:  unix.RTPROT_STATIC,
 					Table:     kiloTableIndex,
 				},
@@ -886,6 +888,7 @@ func TestRoutes(t *testing.T) {
 					Flags:     int(netlink.FLAG_ONLINK),
 					Gw:        nodes["b"].InternalIP.IP,
 					LinkIndex: tunlIface,
+					Src:       nodes["c"].InternalIP.IP,
 					Protocol:  unix.RTPROT_STATIC,
 				},
 				{
@@ -893,6 +896,7 @@ func TestRoutes(t *testing.T) {
 					Flags:     int(netlink.FLAG_ONLINK),
 					Gw:        nodes["b"].InternalIP.IP,
 					LinkIndex: tunlIface,
+					Src:       nodes["c"].InternalIP.IP,
 					Protocol:  unix.RTPROT_STATIC,
 				},
 				{
@@ -900,6 +904,7 @@ func TestRoutes(t *testing.T) {
 					Flags:     int(netlink.FLAG_ONLINK),
 					Gw:        nodes["b"].InternalIP.IP,
 					LinkIndex: tunlIface,
+					Src:       nodes["c"].InternalIP.IP,
 					Protocol:  unix.RTPROT_STATIC,
 				},
 				{
@@ -907,6 +912,7 @@ func TestRoutes(t *testing.T) {
 					Flags:     int(netlink.FLAG_ONLINK),
 					Gw:        nodes["b"].InternalIP.IP,
 					LinkIndex: tunlIface,
+					Src:       nodes["c"].InternalIP.IP,
 					Protocol:  unix.RTPROT_STATIC,
 				},
 				{
@@ -914,6 +920,7 @@ func TestRoutes(t *testing.T) {
 					Flags:     int(netlink.FLAG_ONLINK),
 					Gw:        nodes["b"].InternalIP.IP,
 					LinkIndex: tunlIface,
+					Src:       nodes["c"].InternalIP.IP,
 					Protocol:  unix.RTPROT_STATIC,
 				},
 				{
@@ -921,6 +928,7 @@ func TestRoutes(t *testing.T) {
 					Flags:     int(netlink.FLAG_ONLINK),
 					Gw:        nodes["b"].InternalIP.IP,
 					LinkIndex: tunlIface,
+					Src:       nodes["c"].InternalIP.IP,
 					Protocol:  unix.RTPROT_STATIC,
 					Table:     kiloTableIndex,
 				},
@@ -929,6 +937,7 @@ func TestRoutes(t *testing.T) {
 					Flags:     int(netlink.FLAG_ONLINK),
 					Gw:        nodes["b"].InternalIP.IP,
 					LinkIndex: tunlIface,
+					Src:       nodes["c"].InternalIP.IP,
 					Protocol:  unix.RTPROT_STATIC,
 				},
 				{
@@ -936,6 +945,7 @@ func TestRoutes(t *testing.T) {
 					Flags:     int(netlink.FLAG_ONLINK),
 					Gw:        nodes["b"].InternalIP.IP,
 					LinkIndex: tunlIface,
+					Src:       nodes["c"].InternalIP.IP,
 					Protocol:  unix.RTPROT_STATIC,
 				},
 				{
@@ -943,6 +953,7 @@ func TestRoutes(t *testing.T) {
 					Flags:     int(netlink.FLAG_ONLINK),
 					Gw:        nodes["b"].InternalIP.IP,
 					LinkIndex: tunlIface,
+					Src:       nodes["c"].InternalIP.IP,
 					Protocol:  unix.RTPROT_STATIC,
 				},
 				{
@@ -950,6 +961,7 @@ func TestRoutes(t *testing.T) {
 					Flags:     int(netlink.FLAG_ONLINK),
 					Gw:        nodes["b"].InternalIP.IP,
 					LinkIndex: tunlIface,
+					Src:       nodes["c"].InternalIP.IP,
 					Protocol:  unix.RTPROT_STATIC,
 				},
 				{
@@ -957,6 +969,7 @@ func TestRoutes(t *testing.T) {
 					Flags:     int(netlink.FLAG_ONLINK),
 					Gw:        nodes["b"].InternalIP.IP,
 					LinkIndex: tunlIface,
+					Src:       nodes["c"].InternalIP.IP,
 					Protocol:  unix.RTPROT_STATIC,
 				},
 			},


### PR DESCRIPTION
Set Route.Src for routes installed via the kilo interface to the node private IP when available.

Without an explicit source, the kernel may pick the WireGuard overlay address (for example `100.66.0.x`). In environments like Azure SDN this can break return traffic because the overlay address is not routable by the underlay.

Changes in this PR:
- set `Src` on WireGuard-routed `netlink.Route` entries in `Topology.Routes`;
- keep behavior unchanged when a node has no private IP (source remains unset);
- update `TestRoutes` expectations to assert `Src` in logical/full topology scenarios.