### PR TITLE
docs: update userspace WireGuard information

### DIFF
--- a/docs/userspace-wireguard.md
+++ b/docs/userspace-wireguard.md
@@ -6,7 +6,7 @@ This can make sense in cases where
 * not all nodes in a cluster have WireGuard installed; or
 * nodes are effectively immutable and kernel modules cannot be installed.
 
-One example of a userspace implementation of WireGuard is [BoringTun].
+Examples of userspace implementations of WireGuard include [BoringTun] and [wireguard-go].
 
 ## Homogeneous Clusters
 
@@ -15,7 +15,7 @@ This DaemonSet creates a WireGuard interface that Kilo will manage.
 
 > **Note**: in order to avoid race conditions, `kg` needs to be passed the `--create-interface=false` flag. 
 
-An example configuration for a K3s cluster with [BoringTun] can be applied with:
+An example configuration for a K3s cluster with [wireguard-go] can be applied with:
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/squat/kilo/main/manifests/crds.yaml
@@ -37,8 +37,9 @@ kubectl apply -f https://raw.githubusercontent.com/squat/kilo/main/manifests/kil
 This configuration will deploy [nkml](https://github.com/leonnicolas/nkml) as a DaemonSet to label all nodes according to the presence of the WireGuard kernel module.
 It will also create two different DaemonSets with Kilo:
 1. `kilo` without userspace WireGuard; and
-1. `kilo-userspace` with [BoringTun] as a sidecar.
+1. `kilo-userspace` with [wireguard-go] as a sidecar.
 
 > **Note**: because Kilo is dependant on nkml, nkml must be run on the host network before CNI is available and requires a kubeconfig in order to access the Kubernetes API.
 
 [BoringTun]: https://github.com/cloudflare/boringtun
+[wireguard-go]: https://github.com/WireGuard/wireguard-go


### PR DESCRIPTION
In 4506a42193fff7024a920a509a996564fcac9efa we switched from BoringTun
to wireguard-go because of bugs but did not update the documentation to
reflect this change.

Signed-off-by: squat <lserven@gmail.com>
