### PR TITLE
perf: make e2e test setup concurrent

### DIFF
--- a/e2e/handlers.sh
+++ b/e2e/handlers.sh
@@ -3,9 +3,7 @@
 . lib.sh
 
 setup_suite() {
-	# shellcheck disable=SC2016
 	block_until_ready_by_name kube-system kilo-userspace 
-	_kubectl wait pod -l app.kubernetes.io/name=adjacency --for=condition=Ready --timeout 3m
 }
 
 test_graph_handler() {

--- a/e2e/kgctl.sh
+++ b/e2e/kgctl.sh
@@ -3,9 +3,7 @@
 . lib.sh
 
 setup_suite() {
-	# shellcheck disable=SC2016
 	block_until_ready_by_name kube-system kilo-userspace 
-	_kubectl wait pod -l app.kubernetes.io/name=adjacency --for=condition=Ready --timeout 3m
 }
 
 test_connect() {


### PR DESCRIPTION
Batch the application of workloads as much as possible rather than
creating+waiting several times in a row. This will help speed up e2e
test setup.

Signed-off-by: squat <lserven@gmail.com>
