### PR TITLE
fix: unblock Nix updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765472234,
-        "narHash": "sha256-9VvC20PJPsleGMewwcWYKGzDIyjckEz8uWmT0vCDYK0=",
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2fbfb1d73d239d2402a8fe03963e37aab15abe8b",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This commit works around issues introduced by
https://github.com/NixOS/nixpkgs/pull/470709 that broke the way that
environment variables attributes are extended in `buildGoModule` and
thus prevented bumping the nixpkgs flake input beyond December.

Signed-off-by: squat <lserven@gmail.com>
