### PR TITLE
fix(CI): trigger artifact generation on re-publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,6 @@
 on:
   release:
-    types: [created]
+    types: [created, published]
 name: Handle Release
 jobs:
   kgctl:


### PR DESCRIPTION
This allows a failed release job to create assets by unpublishing and
republishing a release.

Signed-off-by: squat <lserven@gmail.com>
