### PR TITLE
misc: migrate images off of Docker Hub

### DIFF
--- a/e2e/helper-curl.yaml
+++ b/e2e/helper-curl.yaml
@@ -20,6 +20,6 @@ spec:
         - /bin/sh
         - -c
         - while [ 1 -eq 1 ] ; do sleep 10; done
-        image: curlimages/curl
+        image: ghcr.io/curl/curl-container/curl:master
         name: curl
       restartPolicy: Always

--- a/e2e/kilo-kind-userspace.yaml
+++ b/e2e/kilo-kind-userspace.yaml
@@ -141,7 +141,7 @@ spec:
           mountPath: /etc/kubernetes
           readOnly: true
       - name: wireguard
-        image: masipcat/wireguard-go:0.0.20230223
+        image: ghcr.io/masipcat/wireguard-go-docker:0.0.20230223
         args:
         - wireguard-go
         - --foreground

--- a/manifests/kilo-k3s-userspace-heterogeneous.yaml
+++ b/manifests/kilo-k3s-userspace-heterogeneous.yaml
@@ -299,7 +299,7 @@ spec:
           mountPath: /var/run/wireguard
           readOnly: false
       - name: wireguard
-        image: masipcat/wireguard-go:0.0.20230223:cc19859
+        image: ghcr.io/masipcat/wireguard-go-docker:0.0.20230223
         args:
         - wireguard-go
         - --foreground
@@ -411,7 +411,7 @@ spec:
       serviceAccountName: kilo
       containers:
       - name: nkml
-        image: leonnicolas/nkml
+        image: ghcr.io/leonnicolas/nkml:0.1.2
         args:
         - --hostname=$(NODE_NAME)
         - --label-mod=wireguard

--- a/manifests/kilo-k3s-userspace.yaml
+++ b/manifests/kilo-k3s-userspace.yaml
@@ -166,7 +166,7 @@ spec:
           mountPath: /var/run/wireguard
           readOnly: false
       - name: wireguard
-        image: masipcat/wireguard-go:0.0.20230223:cc19859
+        image: ghcr.io/masipcat/wireguard-go-docker:0.0.20230223
         args:
         - wireguard-go
         - --foreground

--- a/manifests/kilo-kubeadm-flannel-userspace.yaml
+++ b/manifests/kilo-kubeadm-flannel-userspace.yaml
@@ -67,7 +67,7 @@ spec:
       hostNetwork: true
       containers:
       - name: wireguard
-        image: masipcat/wireguard-go:0.0.20230223:cc19859
+        image: ghcr.io/masipcat/wireguard-go-docker:0.0.20230223
         args:
         - wireguard-go=true
         - --foreground

--- a/manifests/kilo-kubeadm-userspace.yaml
+++ b/manifests/kilo-kubeadm-userspace.yaml
@@ -101,7 +101,7 @@ spec:
       hostNetwork: true
       containers:
       - name: wireguard
-        image: masipcat/wireguard-go:0.0.20230223:cc19859
+        image: ghcr.io/masipcat/wireguard-go-docker:0.0.20230223
         imagePullPolicy: IfNotPresent
         args:
         - wireguard-go


### PR DESCRIPTION
Docker Hub has very strict and low rate limits for pulling images, which
makes it easy to break the e2e test suite locally. This is because Kind,
by default, does not load all images from the host system's Docker cache
into the Kind nodes. As a result, every time the e2e starts up, all of
the Kind nodes need to re-download all containers. By moving key images
like adjacency, curl and wireguard-go to GHCR, we effectively eliminate
any dependency on Docker Hub and enable running and re-running the e2e
test suite without hitting any rate-limits.
