### PR TITLE
ci: allow kvaps to attach to e2e breakpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         uses: namespacelabs/breakpoint-action@v0
         with:
           duration: 15m
-          authorized-users: squat, leonnicolas
+          authorized-users: squat, leonnicolas, kvaps
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds my GitHub username to the breakpoint `authorized-users` so I can
SSH into the runner when the e2e job fails on PRs I'm involved in
(currently #490 / #491), per your suggestion in #489.